### PR TITLE
fix: usage.jsonl timestamp column name mismatch

### DIFF
--- a/hooks/observe.py
+++ b/hooks/observe.py
@@ -49,7 +49,7 @@ def handle_post_tool_use(event: dict) -> None:
         skill_name = tool_input.get("skill", "unknown")
         usage_record = {
             "skill_name": skill_name,
-            "timestamp": now,
+            "ts": now,
             "session_id": session_id,
             "file_path": tool_input.get("args", ""),
             "project": project,

--- a/hooks/tests/test_hooks.py
+++ b/hooks/tests/test_hooks.py
@@ -1301,7 +1301,7 @@ class TestPruneParentSkill:
         records = [
             {
                 "skill_name": "Agent:Explore",
-                "timestamp": "2026-03-03T10:00:00+00:00",
+                "ts": "2026-03-03T10:00:00+00:00",
             },
         ]
         usage_file.write_text(

--- a/scripts/lib/audit.py
+++ b/scripts/lib/audit.py
@@ -532,7 +532,7 @@ def load_usage_data(
 
     # 日数フィルタ
     cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
-    return [r for r in records if r.get("timestamp", "") >= cutoff]
+    return [r for r in records if r.get("ts", r.get("timestamp", "")) >= cutoff]
 
 
 from agent_classifier import BUILTIN_AGENT_NAMES

--- a/scripts/lib/telemetry_query.py
+++ b/scripts/lib/telemetry_query.py
@@ -102,12 +102,12 @@ def query_usage(
         return []
 
     if HAS_DUCKDB:
-        return _duckdb_query_file(filepath, project=project, include_unknown=include_unknown, since=since, until=until)
+        return _duckdb_query_file(filepath, project=project, include_unknown=include_unknown, since=since, until=until, timestamp_field="ts")
 
     _warn_no_duckdb()
     records = _load_jsonl(filepath)
     records = _filter_by_project(records, project, include_unknown)
-    return _filter_by_time(records, since, until)
+    return _filter_by_time(records, since, until, timestamp_field="ts")
 
 
 def query_errors(
@@ -198,15 +198,16 @@ def query_sessions(
 
 def _build_time_where(
     since: Optional[str], until: Optional[str], params: Dict[str, Any],
+    timestamp_field: str = "timestamp",
 ) -> str:
     """since/until の WHERE 句断片を生成する。"""
     clauses = []
     if since:
         params["since"] = since
-        clauses.append("timestamp >= $since")
+        clauses.append(f"{timestamp_field} >= $since")
     if until:
         params["until"] = until
-        clauses.append("timestamp < $until")
+        clauses.append(f"{timestamp_field} < $until")
     return " AND ".join(clauses)
 
 
@@ -217,6 +218,7 @@ def _duckdb_query_file(
     include_unknown: bool = False,
     since: Optional[str] = None,
     until: Optional[str] = None,
+    timestamp_field: str = "timestamp",
 ) -> List[Dict[str, Any]]:
     """DuckDB で JSONL ファイルをクエリする。
 
@@ -246,7 +248,7 @@ def _duckdb_query_file(
                     where_parts.append("project = $project")
 
         # 時間範囲フィルタ
-        time_clause = _build_time_where(since, until, params)
+        time_clause = _build_time_where(since, until, params, timestamp_field=timestamp_field)
         if time_clause:
             where_parts.append(time_clause)
 
@@ -507,7 +509,7 @@ def _aggregate_skill_sessions(
     window_seconds = TRACE_WINDOW_MINUTES * 60
 
     for sid, session_records in by_session.items():
-        sorted_recs = sorted(session_records, key=lambda r: r.get("timestamp", ""))
+        sorted_recs = sorted(session_records, key=lambda r: r.get("ts", r.get("timestamp", "")))
 
         skill_fires = []
         for i, rec in enumerate(sorted_recs):
@@ -518,14 +520,14 @@ def _aggregate_skill_sessions(
             continue
 
         for fire_idx, (pos, fire_rec) in enumerate(skill_fires):
-            fire_ts = _parse_ts(fire_rec.get("timestamp", ""))
+            fire_ts = _parse_ts(fire_rec.get("ts", fire_rec.get("timestamp", "")))
             if fire_ts is None:
                 continue
 
             next_skill_ts = None
             for j in range(pos + 1, len(sorted_recs)):
                 if sorted_recs[j].get("tool_name") == "Skill":
-                    next_skill_ts = _parse_ts(sorted_recs[j].get("timestamp", ""))
+                    next_skill_ts = _parse_ts(sorted_recs[j].get("ts", sorted_recs[j].get("timestamp", "")))
                     break
 
             window_end_ts = fire_ts.timestamp() + window_seconds
@@ -536,18 +538,18 @@ def _aggregate_skill_sessions(
             errors = 0
             read_edit_cycles = 0
             last_was_read = False
-            last_ts_str = fire_rec.get("timestamp", "")
+            last_ts_str = fire_rec.get("ts", fire_rec.get("timestamp", ""))
 
             for j in range(pos + 1, len(sorted_recs)):
                 rec = sorted_recs[j]
-                rec_ts = _parse_ts(rec.get("timestamp", ""))
+                rec_ts = _parse_ts(rec.get("ts", rec.get("timestamp", "")))
                 if rec_ts is None:
                     continue
                 if rec_ts.timestamp() >= window_end_ts:
                     break
 
                 tool_calls += 1
-                last_ts_str = rec.get("timestamp", last_ts_str)
+                last_ts_str = rec.get("ts", rec.get("timestamp", last_ts_str))
 
                 if rec.get("error"):
                     errors += 1

--- a/scripts/tests/test_quality_monitor.py
+++ b/scripts/tests/test_quality_monitor.py
@@ -146,9 +146,9 @@ def test_resolve_skill_path_global(tmp_path):
 def test_find_high_freq_skills():
     """高頻度 global/plugin スキルの検出。"""
     usage_data = [
-        {"skill_name": "commit", "timestamp": datetime.now(timezone.utc).isoformat()},
+        {"skill_name": "commit", "ts": datetime.now(timezone.utc).isoformat()},
     ] * 15 + [
-        {"skill_name": "rarely", "timestamp": datetime.now(timezone.utc).isoformat()},
+        {"skill_name": "rarely", "ts": datetime.now(timezone.utc).isoformat()},
     ] * 3
 
     mock_path = Path("/fake/.claude/skills/commit/SKILL.md")

--- a/scripts/tests/test_telemetry_query.py
+++ b/scripts/tests/test_telemetry_query.py
@@ -15,11 +15,11 @@ def usage_file(tmp_path):
     """テスト用 usage.jsonl を作成する。"""
     filepath = tmp_path / "usage.jsonl"
     records = [
-        {"skill_name": "my-skill", "project": "atlas", "timestamp": "2026-03-01T00:00:00Z"},
-        {"skill_name": "my-skill", "project": "atlas", "timestamp": "2026-03-01T01:00:00Z"},
-        {"skill_name": "other-skill", "project": "beta", "timestamp": "2026-03-01T02:00:00Z"},
-        {"skill_name": "my-skill", "project": None, "timestamp": "2026-03-01T03:00:00Z"},
-        {"skill_name": "legacy-skill", "timestamp": "2026-03-01T04:00:00Z"},  # project フィールドなし
+        {"skill_name": "my-skill", "project": "atlas", "ts": "2026-03-01T00:00:00Z"},
+        {"skill_name": "my-skill", "project": "atlas", "ts": "2026-03-01T01:00:00Z"},
+        {"skill_name": "other-skill", "project": "beta", "ts": "2026-03-01T02:00:00Z"},
+        {"skill_name": "my-skill", "project": None, "ts": "2026-03-01T03:00:00Z"},
+        {"skill_name": "legacy-skill", "ts": "2026-03-01T04:00:00Z"},  # project フィールドなし
     ]
     filepath.write_text("\n".join(json.dumps(r) for r in records) + "\n")
     return filepath


### PR DESCRIPTION
## Summary
- `usage.jsonl` の実データは `ts` カラムだが、DuckDB クエリ層が `timestamp` を参照していたため `skill_evolve` フェーズで Binder Error が発生していた
- `_build_time_where` / `_duckdb_query_file` に `timestamp_field` パラメータを追加し、`query_usage` から `ts` を渡すように修正
- `observe.py` の書き込みも `ts` に統一、既存データの後方互換性を維持

## Test plan
- [x] `scripts/tests/test_telemetry_query.py` 全27テスト通過
- [x] `scripts/tests/` + `hooks/tests/` 全1297テスト通過

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)