### PR TITLE
chore(release): v1.28.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rl-anything",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "スキル/ルールの直接パッチ最適化と自律進化ループ",
   "author": {
     "name": "min-sys"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [1.28.0] - 2026-04-15
 
 ### Added
 - **philosophy-review スキル**: Claude Code native セッション履歴 (`~/.claude/projects/<slug>/*.jsonl`) を Judge LLM (haiku) で評価し、`category: "philosophy"` 原則の違反例を corrections.jsonl に注入する月1手動レビュー機能。`reflect` ループに乗せて rule/memory 化判断する設計
@@ -8,7 +8,9 @@
 - **principles.py category enum 拡張**: `_build_extraction_prompt` の category enum に `philosophy` を追加。openspec の seed セクションを「数値固定」から「カテゴリ別構造」に再構造化
 
 ### Fixed
-- **philosophy-review の SEED フォールバック**: principles.json cache が SEED 追加前に生成されていた場合でも philosophy 原則を評価対象にできるよう、`SEED_PRINCIPLES` から直接マージ。cache の `user_defined: true` エントリは優先される
+- **philosophy-review SEED フォールバック**: principles.json cache が SEED 追加前に生成されていた場合でも philosophy 原則を評価対象にできるよう、`SEED_PRINCIPLES` から直接マージ。cache の `user_defined: true` エントリは優先される
+- **philosophy-review hardening (1回目)**: LLM が hallucinate した principle_id を drop、confidence を [0.0, 1.0] に clamp + 非数値を reject、`_slug_from_cwd` を Claude Code 仕様（`.`/`_` 置換+連続 dash 圧縮）に整合し実在 dir fallback を追加、token cap をブロック境界 truncation に変更、prompt injection hardening (BEGIN/END markers + data-not-instructions 宣言)、cache 破損 entry ガード
+- **philosophy-review hardening (2回目)**: 先頭巨大ブロック時に後続 tail を保持（以前は head/tail 両方空の場合のみ fallback）、transcript 内の marker 文字列を `[BEGIN_MARKER]`/`[END_MARKER]` に置換し prompt 境界偽装を防止、`_sanitize_violation` が入力 dict を mutate せず shallow copy を返すよう変更
 
 ## [1.27.1] - 2026-04-13
 


### PR DESCRIPTION
v1.27.1 → v1.28.0 (MINOR: feat philosophy-review)

## 変更概要

philosophy-review スキル新設 + SEED_PRINCIPLES philosophy 拡張 (PR #64 で merge 済み)。

## CHANGELOG

### Added
- philosophy-review スキル (Claude Code セッション履歴の Judge LLM 評価)
- SEED_PRINCIPLES に Karpathy 4原則追加 (ADR-020)
- principles.py category enum 拡張

### Fixed
- SEED フォールバック
- 2回の adversarial review 経由の hardening (principle_id 検証 / confidence clamp / slug / truncation / prompt injection / marker injection / no-mutation)

## 検証
- 50/50 tests pass
- 実セッション dry-run 動作確認済み
- `claude plugin validate` PASS