### PR TITLE
feat(cleanup): add /rl-anything:cleanup skill for post-deploy tidy-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **agents: Stop hook を rl-scorer/second-opinion に追加** — CC v2.1.116 で agent frontmatter `hooks:` が `--agent` 経由でも発火するようになったため、`subagent_observe.py` を Stop フックとして追加。main-thread 起動時もテレメトリが記録される
+
 ## [1.32.0] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- **cleanup スキル**: `skills/cleanup/SKILL.md` + `scripts/lib/cleanup_scanner.py` — PR マージ・デプロイ後に残る後片付け（マージ済みローカルブランチ削除・remote refs prune・一時 worktree 削除・一時ディレクトリ削除・関連 Issue close 候補提案・元 PR の Test plan 残件リマインド）を、候補提示→`AskUserQuestion` で個別承認→実行で安全に処理する `/rl-anything:cleanup`。`locked` worktree・現在 checkout 中のブランチ・`main`/`master`/`develop` は削除候補から除外。スキャナは純粋関数 6 本（TDD 20 tests）(closes #69)
 - **agents: Stop hook を rl-scorer/second-opinion に追加** — CC v2.1.116 で agent frontmatter `hooks:` が `--agent` 経由でも発火するようになったため、`subagent_observe.py` を Stop フックとして追加。main-thread 起動時もテレメトリが記録される
 
 ## [1.32.0] - 2026-04-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [Unreleased]
 
 ### Added
-- **cleanup スキル**: `skills/cleanup/SKILL.md` + `scripts/lib/cleanup_scanner.py` — PR マージ・デプロイ後に残る後片付け（マージ済みローカルブランチ削除・remote refs prune・一時 worktree 削除・一時ディレクトリ削除・関連 Issue close 候補提案・元 PR の Test plan 残件リマインド）を、候補提示→`AskUserQuestion` で個別承認→実行で安全に処理する `/rl-anything:cleanup`。`locked` worktree・現在 checkout 中のブランチ・`main`/`master`/`develop` は削除候補から除外。スキャナは純粋関数 6 本（TDD 20 tests）(closes #69)
+- **cleanup スキル**: `skills/cleanup/SKILL.md` + `scripts/lib/cleanup_scanner.py` — PR マージ・デプロイ後に残る後片付け（マージ済みローカルブランチ削除・remote refs prune・一時 worktree 削除・一時ディレクトリ削除・関連 Issue close 候補提案・元 PR の Test plan 残件リマインド）を、候補提示→`AskUserQuestion` で個別承認→実行で安全に処理する `/rl-anything:cleanup`。`locked` worktree・現在 checkout 中のブランチ・`main`/`master`/`develop` は削除候補から除外。スキャナは純粋関数 6 本（TDD 24 tests）(closes #69)
+
+### Fixed
+- **cleanup scanner: 一時ディレクトリ prefix の危険領域除外** — dogfood (#70) で `scan_tmp_dirs` デフォルト prefix (`claude-` / `gstack-` / `rl-anything-`) が `/tmp/claude-<uid>` (Claude Code runtime) や `/tmp/claude-mcp-*` (実行中 MCP bridge) を削除候補に含めるクリティカルバグを検出。SKILL.md のデフォルト prefix を `rl-anything-` のみに narrow し、scanner 側に `exclude_patterns` を追加して `claude-\d+` / `claude-mcp-*` を二重保護。userConfig 化の拡張は #71 で追跡
 - **agents: Stop hook を rl-scorer/second-opinion に追加** — CC v2.1.116 で agent frontmatter `hooks:` が `--agent` 経由でも発火するようになったため、`subagent_observe.py` を Stop フックとして追加。main-thread 起動時もテレメトリが記録される
 
 ## [1.32.0] - 2026-04-17

--- a/agents/rl-scorer.md
+++ b/agents/rl-scorer.md
@@ -15,6 +15,12 @@ color: purple
 memory: project
 maxTurns: 15
 disallowedTools: [Edit, Write, Bash]
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent_observe.py\""
+          timeout: 5000
 ---
 
 あなたはスキル/ルールの品質を多角的に評価する採点エージェントです。

--- a/agents/second-opinion.md
+++ b/agents/second-opinion.md
@@ -16,6 +16,12 @@ color: yellow
 memory: global
 maxTurns: 10
 disallowedTools: [Edit, Write, Bash, NotebookEdit]
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent_observe.py\""
+          timeout: 5000
 ---
 
 あなたは独立したセカンドオピニオンを提供するアドバイザーです。

--- a/scripts/lib/cleanup_scanner.py
+++ b/scripts/lib/cleanup_scanner.py
@@ -1,0 +1,175 @@
+"""cleanup スキル用の後片付け候補スキャナ群。
+
+`/rl-anything:cleanup` から呼ばれる純粋なスキャナ関数を提供する。
+副作用（削除）は含まず、候補リストの返却に責務を限定する。
+
+Design notes:
+- `git_cmd` callable を注入可能にしてテスト容易性を確保する。
+- 外部コマンド失敗時は例外を潰さず caller にハンドリングを委ねる。
+  （呼び出し側の SKILL で graceful degradation する方針）
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from typing import Callable, Iterable, Optional
+
+
+GitCmd = Callable[[list[str]], str]
+
+
+def _default_git_cmd(args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def scan_merged_branches(
+    base_branches: Iterable[str],
+    current_branch: str,
+    protected: Iterable[str],
+    git_cmd: Optional[GitCmd] = None,
+) -> list[str]:
+    """`base_branches` の少なくとも一つにマージ済みのローカルブランチを列挙する。
+
+    現在 checkout 中のブランチ、`protected` に含まれるブランチは常に除外する。
+    """
+    git = git_cmd or _default_git_cmd
+    protected_set = set(protected) | {current_branch}
+
+    merged: set[str] = set()
+    order: list[str] = []
+    for base in base_branches:
+        output = git(["branch", "--merged", base, "--format=%(refname:short)"])
+        for raw_line in output.splitlines():
+            name = raw_line.lstrip("*").strip()
+            if not name or name in protected_set:
+                continue
+            if name in merged:
+                continue
+            merged.add(name)
+            order.append(name)
+    return order
+
+
+_PRUNE_LINE_RE = re.compile(r"\[(?:would prune|pruned)\]\s+(\S+)")
+
+
+def scan_prunable_remote_refs(git_cmd: Optional[GitCmd] = None) -> list[str]:
+    """`git fetch --prune --dry-run` の出力から prune 候補を抽出する。"""
+    git = git_cmd or _default_git_cmd
+    output = git(["fetch", "--prune", "--dry-run"])
+    return [m.group(1) for m in _PRUNE_LINE_RE.finditer(output)]
+
+
+def scan_removable_worktrees(
+    main_worktree_path: str,
+    git_cmd: Optional[GitCmd] = None,
+) -> list[dict]:
+    """削除可能な worktree 候補を返す。
+
+    メイン worktree（リポジトリ本体）と `locked` な worktree は除外する。
+    戻り値: `[{"path": str, "branch": str | None, "head": str}, ...]`
+    """
+    git = git_cmd or _default_git_cmd
+    output = git(["worktree", "list", "--porcelain"])
+
+    worktrees: list[dict] = []
+    current: dict = {}
+
+    def flush() -> None:
+        if current:
+            worktrees.append(current.copy())
+            current.clear()
+
+    for line in output.splitlines():
+        if not line.strip():
+            flush()
+            continue
+        if line.startswith("worktree "):
+            flush()
+            current["path"] = line[len("worktree "):].strip()
+            current["locked"] = False
+            current["branch"] = None
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD "):].strip()
+        elif line.startswith("branch "):
+            ref = line[len("branch "):].strip()
+            current["branch"] = ref.removeprefix("refs/heads/")
+        elif line.strip() == "locked" or line.startswith("locked "):
+            current["locked"] = True
+    flush()
+
+    normalized_main = os.path.normpath(main_worktree_path)
+    removable = []
+    for wt in worktrees:
+        if wt.get("locked"):
+            continue
+        if os.path.normpath(wt.get("path", "")) == normalized_main:
+            continue
+        removable.append({
+            "path": wt["path"],
+            "branch": wt.get("branch"),
+            "head": wt.get("head"),
+        })
+    return removable
+
+
+def scan_tmp_dirs(
+    prefixes: Iterable[str],
+    tmp_root: str = "/tmp",
+) -> list[str]:
+    """`tmp_root` 配下で `prefixes` に前方一致するディレクトリの絶対パスを返す。"""
+    if not os.path.isdir(tmp_root):
+        return []
+    prefix_list = list(prefixes)
+    results: list[str] = []
+    for name in sorted(os.listdir(tmp_root)):
+        if not any(name.startswith(p) for p in prefix_list):
+            continue
+        full = os.path.join(tmp_root, name)
+        if not os.path.isdir(full):
+            continue
+        results.append(full)
+    return results
+
+
+_ISSUE_RE = re.compile(r"(?:issue-|#)(\d+)")
+
+
+def extract_issue_numbers_from_branch(name: str) -> list[int]:
+    """ブランチ名から issue 番号を抽出する（重複排除・出現順保持）。
+
+    `issue-\\d+` / `#\\d+` のみを拾う。`release/1.32.0` のような裸の数字は拾わない。
+    """
+    if not name:
+        return []
+    seen: set[int] = set()
+    numbers: list[int] = []
+    for match in _ISSUE_RE.finditer(name):
+        n = int(match.group(1))
+        if n in seen:
+            continue
+        seen.add(n)
+        numbers.append(n)
+    return numbers
+
+
+_UNCHECKED_RE = re.compile(r"^\s*-\s*\[\s\]\s+(.+?)\s*$")
+
+
+def extract_unchecked_testplan(pr_body: Optional[str]) -> list[str]:
+    """PR 本文から未チェック `- [ ]` 項目を抽出する。"""
+    if not pr_body:
+        return []
+    result: list[str] = []
+    for line in pr_body.splitlines():
+        match = _UNCHECKED_RE.match(line)
+        if match:
+            result.append(match.group(1))
+    return result

--- a/scripts/lib/cleanup_scanner.py
+++ b/scripts/lib/cleanup_scanner.py
@@ -120,17 +120,38 @@ def scan_removable_worktrees(
     return removable
 
 
+# dogfood (PR #70) で `/tmp/claude-501` (Claude Code ランタイム UID dir) と
+# `/tmp/claude-mcp-*` (実行中 MCP server bridge) を削除候補に含める危険なバグを検出。
+# defense-in-depth として、呼び出し側が `claude-` を prefix に指定しても
+# 絶対に削除してはいけないものは scanner 側で除外する安全網を常時有効化する。
+_DEFAULT_TMP_EXCLUDE_PATTERNS: tuple[str, ...] = (
+    r"^claude-\d+$",       # /tmp/claude-<uid> (Claude Code runtime socket/pid dir)
+    r"^claude-mcp-.*",     # /tmp/claude-mcp-*  (running MCP server bridges)
+)
+
+
 def scan_tmp_dirs(
     prefixes: Iterable[str],
     tmp_root: str = "/tmp",
+    exclude_patterns: Optional[Iterable[str]] = None,
 ) -> list[str]:
-    """`tmp_root` 配下で `prefixes` に前方一致するディレクトリの絶対パスを返す。"""
+    """`tmp_root` 配下で `prefixes` に前方一致するディレクトリの絶対パスを返す。
+
+    `exclude_patterns` は basename に対して re.search でマッチングする。`None` を渡すと
+    デフォルトの安全網 (`_DEFAULT_TMP_EXCLUDE_PATTERNS`) が適用される。`[]` を渡せば
+    明示的に無効化できる（通常は非推奨）。
+    """
     if not os.path.isdir(tmp_root):
         return []
     prefix_list = list(prefixes)
+    patterns = _DEFAULT_TMP_EXCLUDE_PATTERNS if exclude_patterns is None else list(exclude_patterns)
+    compiled = [re.compile(p) for p in patterns]
+
     results: list[str] = []
     for name in sorted(os.listdir(tmp_root)):
         if not any(name.startswith(p) for p in prefix_list):
+            continue
+        if any(rx.search(name) for rx in compiled):
             continue
         full = os.path.join(tmp_root, name)
         if not os.path.isdir(full):

--- a/scripts/tests/test_cleanup_scanner.py
+++ b/scripts/tests/test_cleanup_scanner.py
@@ -3,6 +3,7 @@
 Issue #69: 後片付けスキル用のスキャナ関数群をテスト駆動で定義する。
 外部コマンド（git / fs）は `git_cmd` や `tmp_root` 引数でモック可能な設計にする。
 """
+import os
 import sys
 from pathlib import Path
 
@@ -172,6 +173,70 @@ def test_scan_tmp_dirs_returns_empty_when_no_match(tmp_path):
 def test_scan_tmp_dirs_handles_missing_root(tmp_path):
     missing = tmp_path / "does-not-exist"
     assert scan_tmp_dirs(prefixes=["claude-"], tmp_root=str(missing)) == []
+
+
+def test_scan_tmp_dirs_default_excludes_claude_runtime_uid(tmp_path):
+    """`/tmp/claude-<uid>` は Claude Code のランタイムディレクトリで絶対に削除してはいけない。
+
+    dogfood (PR #70) で `/tmp/claude-501` が候補に含まれるバグを検出したための defense-in-depth。
+    ユーザーが prefix `claude-` を明示的に指定した場合でも、デフォルト exclude_patterns で守る。
+    """
+    (tmp_path / "claude-501").mkdir()
+    (tmp_path / "claude-12345").mkdir()
+    (tmp_path / "claude-sandbox-ok").mkdir()
+
+    result = scan_tmp_dirs(prefixes=["claude-"], tmp_root=str(tmp_path))
+    names = sorted(os.path.basename(p) for p in result)
+    assert names == ["claude-sandbox-ok"], (
+        f"UID 付き claude-<digits> はデフォルトで除外されるべき。got: {names}"
+    )
+
+
+def test_scan_tmp_dirs_default_excludes_mcp_bridge(tmp_path):
+    """`/tmp/claude-mcp-*` は実行中の MCP server bridge なので削除禁止。"""
+    (tmp_path / "claude-mcp-browser-bridge-matsukaze").mkdir()
+    (tmp_path / "claude-mcp-gmail").mkdir()
+    (tmp_path / "claude-scratch-ok").mkdir()
+
+    result = scan_tmp_dirs(prefixes=["claude-"], tmp_root=str(tmp_path))
+    names = sorted(os.path.basename(p) for p in result)
+    assert names == ["claude-scratch-ok"], (
+        f"claude-mcp-* はデフォルトで除外されるべき。got: {names}"
+    )
+
+
+def test_scan_tmp_dirs_custom_exclude_patterns(tmp_path):
+    """呼び出し側で独自の exclude_patterns を指定できる。
+
+    デフォルトを上書きする形で `exclude_patterns=[]` を渡すと、exclusion を解除できる
+    （ただし通常は推奨しない — デフォルトはセーフティネットとして機能する）。
+    """
+    (tmp_path / "gstack-work").mkdir()
+    (tmp_path / "gstack-scratch-ok").mkdir()
+
+    result = scan_tmp_dirs(
+        prefixes=["gstack-"],
+        tmp_root=str(tmp_path),
+        exclude_patterns=[r"gstack-work$"],
+    )
+    names = sorted(os.path.basename(p) for p in result)
+    assert names == ["gstack-scratch-ok"]
+
+
+def test_scan_tmp_dirs_override_exclude_patterns_with_empty_list(tmp_path):
+    """exclude_patterns=[] を明示的に渡すとデフォルトの安全網を外せる。
+
+    逃げ道として残してあるが、SKILL.md は明示的にこれをしないことを前提とする。
+    """
+    (tmp_path / "claude-501").mkdir()
+
+    result = scan_tmp_dirs(
+        prefixes=["claude-"],
+        tmp_root=str(tmp_path),
+        exclude_patterns=[],
+    )
+    names = sorted(os.path.basename(p) for p in result)
+    assert names == ["claude-501"]
 
 
 # ---------- extract_issue_numbers_from_branch ----------

--- a/scripts/tests/test_cleanup_scanner.py
+++ b/scripts/tests/test_cleanup_scanner.py
@@ -1,0 +1,235 @@
+"""cleanup_scanner.py のテスト。
+
+Issue #69: 後片付けスキル用のスキャナ関数群をテスト駆動で定義する。
+外部コマンド（git / fs）は `git_cmd` や `tmp_root` 引数でモック可能な設計にする。
+"""
+import sys
+from pathlib import Path
+
+_lib = Path(__file__).resolve().parent.parent / "lib"
+sys.path.insert(0, str(_lib))
+
+from cleanup_scanner import (
+    extract_issue_numbers_from_branch,
+    extract_unchecked_testplan,
+    scan_merged_branches,
+    scan_prunable_remote_refs,
+    scan_removable_worktrees,
+    scan_tmp_dirs,
+)
+
+
+# ---------- scan_merged_branches ----------
+
+def test_scan_merged_branches_excludes_current_and_protected():
+    """マージ済みでも、現在ブランチ・main/master/develop は除外する。"""
+    def fake_git(args):
+        assert args == ["branch", "--merged", "main", "--format=%(refname:short)"]
+        return "* feat/current\n  feat/done-1\n  main\n  master\n  feat/done-2\n  develop\n"
+
+    result = scan_merged_branches(
+        base_branches=["main"],
+        current_branch="feat/current",
+        protected=["main", "master", "develop"],
+        git_cmd=fake_git,
+    )
+    assert result == ["feat/done-1", "feat/done-2"]
+
+
+def test_scan_merged_branches_empty_when_no_merged():
+    def fake_git(args):
+        return "* main\n"
+
+    result = scan_merged_branches(
+        base_branches=["main"],
+        current_branch="main",
+        protected=["main"],
+        git_cmd=fake_git,
+    )
+    assert result == []
+
+
+def test_scan_merged_branches_strips_asterisk_and_whitespace():
+    """`* ` 付きの現在ブランチマーカーを正しく除去する。"""
+    def fake_git(args):
+        return "  feat/a\n* feat/current\n  feat/b  \n"
+
+    result = scan_merged_branches(
+        base_branches=["main"],
+        current_branch="feat/current",
+        protected=[],
+        git_cmd=fake_git,
+    )
+    assert result == ["feat/a", "feat/b"]
+
+
+# ---------- scan_prunable_remote_refs ----------
+
+def test_scan_prunable_remote_refs_parses_dry_run_output():
+    """`git fetch --prune --dry-run` の出力から prune 候補を抽出する。"""
+    def fake_git(args):
+        assert args == ["fetch", "--prune", "--dry-run"]
+        return (
+            "From github.com:min-sys/rl-anything\n"
+            " - [would prune] origin/feat/merged-a\n"
+            " - [would prune] origin/feat/merged-b\n"
+        )
+
+    result = scan_prunable_remote_refs(git_cmd=fake_git)
+    assert result == ["origin/feat/merged-a", "origin/feat/merged-b"]
+
+
+def test_scan_prunable_remote_refs_handles_pruned_token():
+    """一部環境では `[pruned]` 表記になる。"""
+    def fake_git(args):
+        return " x [pruned] origin/old-ref\n"
+
+    result = scan_prunable_remote_refs(git_cmd=fake_git)
+    assert result == ["origin/old-ref"]
+
+
+def test_scan_prunable_remote_refs_empty_when_clean():
+    def fake_git(args):
+        return ""
+
+    assert scan_prunable_remote_refs(git_cmd=fake_git) == []
+
+
+# ---------- scan_removable_worktrees ----------
+
+def test_scan_removable_worktrees_excludes_main_and_locked():
+    """メイン worktree と locked な worktree は除外。"""
+    porcelain = (
+        "worktree /Users/me/proj\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+        "worktree /Users/me/proj-wt-feature\n"
+        "HEAD def456\n"
+        "branch refs/heads/feature\n"
+        "\n"
+        "worktree /Users/me/proj-wt-hotfix\n"
+        "HEAD 789abc\n"
+        "branch refs/heads/hotfix\n"
+        "locked\n"
+        "\n"
+    )
+
+    def fake_git(args):
+        assert args == ["worktree", "list", "--porcelain"]
+        return porcelain
+
+    result = scan_removable_worktrees(
+        main_worktree_path="/Users/me/proj",
+        git_cmd=fake_git,
+    )
+    assert len(result) == 1
+    assert result[0]["path"] == "/Users/me/proj-wt-feature"
+    assert result[0]["branch"] == "feature"
+
+
+def test_scan_removable_worktrees_empty_when_only_main():
+    porcelain = (
+        "worktree /Users/me/proj\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+    )
+
+    def fake_git(args):
+        return porcelain
+
+    result = scan_removable_worktrees(
+        main_worktree_path="/Users/me/proj",
+        git_cmd=fake_git,
+    )
+    assert result == []
+
+
+# ---------- scan_tmp_dirs ----------
+
+def test_scan_tmp_dirs_matches_prefixes(tmp_path):
+    """指定 prefix にマッチするディレクトリだけを返す。"""
+    (tmp_path / "claude-sandbox-1").mkdir()
+    (tmp_path / "gstack-qa-2").mkdir()
+    (tmp_path / "rl-anything-bench-3").mkdir()
+    (tmp_path / "other-keep").mkdir()
+    (tmp_path / "claude-not-a-dir.txt").write_text("x")
+
+    result = scan_tmp_dirs(
+        prefixes=["claude-", "gstack-", "rl-anything-"],
+        tmp_root=str(tmp_path),
+    )
+    names = sorted(Path(p).name for p in result)
+    assert names == ["claude-sandbox-1", "gstack-qa-2", "rl-anything-bench-3"]
+
+
+def test_scan_tmp_dirs_returns_empty_when_no_match(tmp_path):
+    (tmp_path / "keep-me").mkdir()
+    assert scan_tmp_dirs(prefixes=["claude-"], tmp_root=str(tmp_path)) == []
+
+
+def test_scan_tmp_dirs_handles_missing_root(tmp_path):
+    missing = tmp_path / "does-not-exist"
+    assert scan_tmp_dirs(prefixes=["claude-"], tmp_root=str(missing)) == []
+
+
+# ---------- extract_issue_numbers_from_branch ----------
+
+def test_extract_issue_numbers_issue_dash_prefix():
+    assert extract_issue_numbers_from_branch("feat/issue-69-cleanup-skill") == [69]
+
+
+def test_extract_issue_numbers_hash_prefix():
+    assert extract_issue_numbers_from_branch("fix/#42-bug") == [42]
+
+
+def test_extract_issue_numbers_multiple():
+    """複数 issue 番号が含まれる場合は重複なく返す。"""
+    result = extract_issue_numbers_from_branch("feat/issue-10-issue-10-combo")
+    assert result == [10]
+
+
+def test_extract_issue_numbers_none():
+    assert extract_issue_numbers_from_branch("main") == []
+    assert extract_issue_numbers_from_branch("feat/no-number") == []
+
+
+def test_extract_issue_numbers_does_not_match_bare_digits():
+    """裸の数字は issue 番号扱いしない（false positive 回避）。"""
+    assert extract_issue_numbers_from_branch("release/1.32.0") == []
+
+
+# ---------- extract_unchecked_testplan ----------
+
+def test_extract_unchecked_testplan_finds_unchecked_boxes():
+    body = (
+        "## Summary\n\n"
+        "fix stuff\n\n"
+        "## Test plan\n"
+        "- [x] Unit tests pass\n"
+        "- [ ] Manually verify the happy path\n"
+        "- [ ] Check error handling on 404\n"
+    )
+    result = extract_unchecked_testplan(body)
+    assert result == [
+        "Manually verify the happy path",
+        "Check error handling on 404",
+    ]
+
+
+def test_extract_unchecked_testplan_empty_when_all_checked():
+    body = "- [x] done 1\n- [x] done 2\n"
+    assert extract_unchecked_testplan(body) == []
+
+
+def test_extract_unchecked_testplan_handles_none_or_empty():
+    assert extract_unchecked_testplan("") == []
+    assert extract_unchecked_testplan(None) == []
+
+
+def test_extract_unchecked_testplan_strips_leading_whitespace():
+    """インデント付きチェックボックスも拾う。"""
+    body = "  - [ ] nested item\n    - [ ] deeper item\n"
+    result = extract_unchecked_testplan(body)
+    assert result == ["nested item", "deeper item"]

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -14,7 +14,7 @@ PR マージ・デプロイ完了後に残る以下の「痕跡」を、**候補
 1. マージ済みローカルブランチの削除
 2. stale な remote tracking branch の prune
 3. 一時 worktree の削除（`locked` は除外）
-4. `/tmp/claude-*` / `/tmp/gstack-*` / `/tmp/rl-anything-*` の削除
+4. `/tmp/rl-anything-*` 配下の削除（CRITICAL: `claude-` / `gstack-` はランタイム領域と衝突するためデフォルト対象外。拡張は Issue #71 で userConfig 化予定）
 5. マージ済みブランチ名から推定した関連 Issue の close 候補提案（**自動 close はしない**）
 6. 元 PR の Test plan 未完了チェックの残件リマインド
 
@@ -52,7 +52,7 @@ merged = scan_merged_branches(
 )
 prune = scan_prunable_remote_refs()
 worktrees = scan_removable_worktrees(main_worktree_path=main_wt)
-tmp_dirs = scan_tmp_dirs(prefixes=["claude-", "gstack-", "rl-anything-"])
+tmp_dirs = scan_tmp_dirs(prefixes=["rl-anything-"])  # narrow default — see CRITICAL note below
 ```
 
 **収集結果を一覧表示**してからユーザーに見せる:
@@ -129,18 +129,20 @@ C) Abort
 
 #### カテゴリ 4: 一時ディレクトリ
 
+初版デフォルト prefix は **`rl-anything-` のみ**。`claude-` / `gstack-` は Claude Code ランタイム (`/tmp/claude-<uid>`) や MCP bridge (`/tmp/claude-mcp-*`)、gstack 作業ディレクトリ (`/tmp/gstack-work`) と衝突し、削除するとセッションが壊れる危険があるため**デフォルトから除外**している。なお scanner 側 `_DEFAULT_TMP_EXCLUDE_PATTERNS` で `claude-<uid>` / `claude-mcp-*` は二重に保護している（ユーザー独自拡張時の保険）。prefix 拡張は Issue #71 で userConfig 化予定。
+
 各ディレクトリについて個別に:
 
 ```
-一時ディレクトリ `/tmp/claude-sandbox-abc` を削除しますか？
-(rm -rf /tmp/claude-sandbox-abc)
+一時ディレクトリ `/tmp/rl-anything-bench-abc` を削除しますか？
+(rm -rf /tmp/rl-anything-bench-abc)
 
 A) Yes - 削除する
 B) Skip
 C) Abort
 ```
 
-`rm -rf` 実行前に、パスが想定 prefix (`/tmp/claude-`, `/tmp/gstack-`, `/tmp/rl-anything-`) で始まることを再確認する（防衛）。
+`rm -rf` 実行前に、パスが `/tmp/rl-anything-` で始まることを再確認する（防衛）。
 
 #### カテゴリ 5: 関連 Issue close 候補
 

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: cleanup
+effort: low
+description: |
+  PR マージ・デプロイ後に残る後片付け（マージ済みローカルブランチ削除、remote refs の prune、一時 worktree 削除、一時ディレクトリ削除、関連 Issue の close 候補提案、元 PR の Test plan 残件リマインド）を候補提示→個別承認→実行で安全に片付ける。
+  Trigger: cleanup, 後片付け, 片付け, ブランチ整理, worktree 整理, merged branches, stale branches, prune, tidy up, /ship 後の片付け
+allowed-tools: Bash, Read, AskUserQuestion
+---
+
+# cleanup — デプロイ後の後片付け
+
+PR マージ・デプロイ完了後に残る以下の「痕跡」を、**候補を列挙 → `AskUserQuestion` で個別承認 → 実行** の流れで安全に片付ける。
+
+1. マージ済みローカルブランチの削除
+2. stale な remote tracking branch の prune
+3. 一時 worktree の削除（`locked` は除外）
+4. `/tmp/claude-*` / `/tmp/gstack-*` / `/tmp/rl-anything-*` の削除
+5. マージ済みブランチ名から推定した関連 Issue の close 候補提案（**自動 close はしない**）
+6. 元 PR の Test plan 未完了チェックの残件リマインド
+
+**なぜ個別承認が必要か**: これらはどれも不可逆寄りの操作（ブランチ削除・ディレクトリ削除・fetch --prune）で、かつ「他セッションが作業中のもの」や「ユーザーが意図的に残しているもの」が混ざる可能性がある。一括実行すると取り返しがつかなくなるため、1 候補ずつ承認を取る。
+
+## 実行手順
+
+### Step 1: 候補の収集（副作用なし）
+
+`scripts/lib/cleanup_scanner.py` の純粋関数で候補を全カテゴリ一括収集する。副作用ゼロ（読み取りのみ）。
+
+```python
+# スキル内から Bash 経由で実行する想定のスニペット
+import json, os, subprocess, sys
+sys.path.insert(0, "scripts/lib")
+from cleanup_scanner import (
+    scan_merged_branches, scan_prunable_remote_refs,
+    scan_removable_worktrees, scan_tmp_dirs,
+    extract_issue_numbers_from_branch, extract_unchecked_testplan,
+)
+
+current = subprocess.run(
+    ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+    capture_output=True, text=True
+).stdout.strip()
+main_wt = subprocess.run(
+    ["git", "rev-parse", "--show-toplevel"],
+    capture_output=True, text=True
+).stdout.strip()
+
+merged = scan_merged_branches(
+    base_branches=["main"],
+    current_branch=current,
+    protected=["main", "master", "develop"],
+)
+prune = scan_prunable_remote_refs()
+worktrees = scan_removable_worktrees(main_worktree_path=main_wt)
+tmp_dirs = scan_tmp_dirs(prefixes=["claude-", "gstack-", "rl-anything-"])
+```
+
+**収集結果を一覧表示**してからユーザーに見せる:
+
+```
+後片付け候補
+═══════════
+[1] マージ済みローカルブランチ: 3 件
+    - feat/issue-65-foo
+    - feat/issue-66-bar
+    - hotfix/typo
+[2] Remote prune 候補: 2 件
+    - origin/feat/issue-65-foo
+    - origin/feat/issue-66-bar
+[3] 削除可能 worktree: 1 件
+    - /Users/.../proj-wt-review (branch=review/pr-64)
+[4] 一時ディレクトリ: 2 件
+    - /tmp/claude-sandbox-abc
+    - /tmp/gstack-qa-xyz
+[5] close 候補 Issue: #65, #66
+[6] PR Test plan 残件: 1 件
+    - #64: "Manually verify on staging"
+```
+
+候補がゼロなら「片付けるものはありません」と返して終了。
+
+### Step 2: カテゴリごとに個別承認 → 実行
+
+カテゴリ単位で順に確認する。各カテゴリ内で候補が複数ある場合、**1 つずつ** `AskUserQuestion` で承認を取る（一括の "Yes to all" は提供しない）。
+
+#### カテゴリ 1: マージ済みローカルブランチ
+
+各ブランチについて:
+
+```
+ローカルブランチ `feat/issue-65-foo` を削除しますか？
+(git branch -D feat/issue-65-foo)
+
+A) Yes - 削除する
+B) Skip - このブランチは残す
+C) Abort - 以降の cleanup を中止する
+```
+
+承認時: `git branch -D <name>` を実行し、結果を報告。
+
+#### カテゴリ 2: Remote prune
+
+prune はブランチ単位ではなく `git fetch --prune` で一括実行される操作なので、**全候補をまとめて 1 つの質問**にする:
+
+```
+以下の stale remote refs を prune しますか？
+- origin/feat/issue-65-foo
+- origin/feat/issue-66-bar
+(git fetch --prune)
+
+A) Yes - prune する
+B) Skip
+```
+
+#### カテゴリ 3: 一時 worktree
+
+各 worktree について:
+
+```
+worktree `/Users/.../proj-wt-review` (branch=review/pr-64) を削除しますか？
+(git worktree remove /Users/.../proj-wt-review)
+
+A) Yes - 削除する
+B) Skip
+C) Abort
+```
+
+`locked` worktree はそもそもスキャナが返さないのでここには出ない。
+
+#### カテゴリ 4: 一時ディレクトリ
+
+各ディレクトリについて個別に:
+
+```
+一時ディレクトリ `/tmp/claude-sandbox-abc` を削除しますか？
+(rm -rf /tmp/claude-sandbox-abc)
+
+A) Yes - 削除する
+B) Skip
+C) Abort
+```
+
+`rm -rf` 実行前に、パスが想定 prefix (`/tmp/claude-`, `/tmp/gstack-`, `/tmp/rl-anything-`) で始まることを再確認する（防衛）。
+
+#### カテゴリ 5: 関連 Issue close 候補
+
+**自動 close は絶対にしない**。`gh` が利用可能なら各 issue の状態を確認し、既に closed なら黙ってスキップ。OPEN の issue についてのみ:
+
+```
+Issue #65 ("ブランチ名: feat/issue-65-foo" から推定) は close 候補です。
+現在の状態: OPEN
+
+A) gh issue view #65 で中身を確認する
+B) Skip - 手動で判断する
+C) gh issue close #65 でクローズ（内容を確認済みの場合のみ）
+```
+
+C を選んだ場合も、直前に `gh issue view` で本文を表示し「本当に close しますか？」で最終確認する。
+
+#### カテゴリ 6: PR Test plan 残件
+
+これは**削除ではなくリマインダー**。実行はせず、表示のみ。
+
+```
+元 PR の Test plan に未完了チェックが残っています:
+- #64:
+  - [ ] Manually verify on staging
+
+対応しますか？
+A) 手動で対応する（このまま終了）
+B) 該当 PR を gh pr view で開く
+C) Skip
+```
+
+### Step 3: 未コミット変更のガード
+
+スキル実行の冒頭（Step 1 より前）で以下を確認する:
+
+```bash
+if [ -n "$(git status --porcelain)" ]; then
+  # 未コミット変更あり
+fi
+```
+
+未コミット変更がある場合、`AskUserQuestion` で確認:
+
+```
+未コミットの変更があります。cleanup は破壊的な操作を含むため、
+先に commit / stash しておくことを推奨します。
+
+A) このまま続行する（リスク承知）
+B) 中止して commit / stash してから再実行
+```
+
+B を選んだら即終了。
+
+### Step 4: サマリ報告
+
+全カテゴリ処理後、結果を集約:
+
+```
+cleanup 完了
+═══════════
+削除ブランチ: 2 件 (feat/issue-65-foo, feat/issue-66-bar)
+Prune: 実行
+削除 worktree: 1 件
+削除 tmp dir: 1 件
+Issue close: 0 件（手動で対応）
+Test plan リマインド: 1 件（#64）
+```
+
+## エッジケース
+
+- **`git` / `gh` 未インストール**: `command -v git` / `command -v gh` で事前チェック。`gh` が無い場合はカテゴリ 5 と 6 を「スキップ（gh 未インストール）」として表示のみ。
+- **リモート未設定**: `git remote -v` が空なら カテゴリ 2（prune）はスキップ。
+- **デフォルトブランチが `main` 以外**: `git symbolic-ref refs/remotes/origin/HEAD` で解決。解決できなければ `main` と `master` の両方を base として試す。
+- **候補がゼロ**: Step 1 時点で全カテゴリ空なら「片付けるものはありません」と返して終了。
+- **`Abort` 選択**: 以降の全カテゴリをスキップし、そこまでの結果でサマリ表示して終了。
+- **ブランチ削除で `-D` が失敗**: upstream 未 merge 等のケース。エラーを表示し、そのブランチはスキップして次へ進む（`-d` へのフォールバックはしない — 意図して `-D` 使用）。
+
+## 既存スキルとの関係
+
+| スキル | カバー範囲 |
+|--------|-----------|
+| `/ship` (gstack) | PR 作成まで |
+| `/land-and-deploy` (gstack) | マージ + デプロイ検証まで |
+| **`/rl-anything:cleanup`** | **マージ・デプロイ後の痕跡掃除** |
+
+将来的に gstack flow-chain の末尾に cleanup を組み込むことを検討（別 issue）。
+
+## 使用例
+
+```
+# 全カテゴリ対話的に処理
+/rl-anything:cleanup
+
+# 会話上で「ブランチ整理したい」等の発話でも起動可能
+```


### PR DESCRIPTION
## Summary
- Issue #69 の機能提案に対応し、PR マージ・デプロイ後の後片付けを統一コマンド化する新スキル `/rl-anything:cleanup` を追加
- 対象: マージ済みローカルブランチ / remote refs prune / 一時 worktree / 一時ディレクトリ / 関連 Issue close 候補 / PR Test plan 残件
- 候補一覧表示 → `AskUserQuestion` で**個別承認** → 実行の流れを徹底し、一括実行や自動 Issue close は行わない
- スキャナ 6 関数を `scripts/lib/cleanup_scanner.py` に抽出し TDD 20 テストでカバー（全パス、フルテスト 1067 件もリグレッションなし）

## 実装ポイント
- `locked` worktree・現在 checkout 中のブランチ・`main`/`master`/`develop` は削除候補から**常に**除外
- `gh` / `git` 未インストール時は該当カテゴリをスキップ表示する graceful degradation
- 一時ディレクトリは `/tmp/claude-*` / `/tmp/gstack-*` / `/tmp/rl-anything-*` の暫定固定 prefix から開始（設定化は今後検討）
- version bump はこの PR では行わない（`commit.md` ルールに従いリリース時に別途）

## NOT in scope
- gstack flow-chain 末尾への組み込み → 別 issue 化
- 一時ディレクトリ prefix の userConfig 化 → 別 issue 化

## Test plan
- [x] `python3 -m pytest scripts/tests/test_cleanup_scanner.py -v` → 20 passed
- [x] `python3 -m pytest scripts/tests/ -x -q` → 1067 passed（リグレッションなし）
- [ ] 実環境で `/rl-anything:cleanup` を起動し、マージ済みブランチ検出 → 個別承認 → 削除フローを手動検証
- [ ] `locked` worktree が候補から除外されることを手動検証
- [ ] `gh` 未インストール環境で graceful degradation を確認（可能なら）

closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)