### PR TITLE
docs(spec,todos): fix PR #38 reference + add fleet Phase 3 TODO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **cleanup スキル**: `skills/cleanup/SKILL.md` + `scripts/lib/cleanup_scanner.py` — PR マージ・デプロイ後に残る後片付け（マージ済みローカルブランチ削除・remote refs prune・一時 worktree 削除・一時ディレクトリ削除・関連 Issue close 候補提案・元 PR の Test plan 残件リマインド）を、候補提示→`AskUserQuestion` で個別承認→実行で安全に処理する `/rl-anything:cleanup`。`locked` worktree・現在 checkout 中のブランチ・`main`/`master`/`develop` は削除候補から除外。スキャナは純粋関数 6 本（TDD 24 tests）(closes #69)
 
 ### Fixed
+- **SPEC.md L75 の PR #38 記載誤り** — 「PR #38 で基盤完了」と記述していたが PR #38 は実際は v1.15.0 (FileChanged hook + MEMORY.md + userConfig) であり cross-project audit の基盤ではなかった。fleet 構想 (issue #68) として再設計する旨に修正。TODOS.md に rl-fleet Phase 3 の `resolve_auto_memory_dir` 特殊文字ケーステスト P2 エントリを追加
 - **cleanup scanner: 一時ディレクトリ prefix の危険領域除外** — dogfood (#70) で `scan_tmp_dirs` デフォルト prefix (`claude-` / `gstack-` / `rl-anything-`) が `/tmp/claude-<uid>` (Claude Code runtime) や `/tmp/claude-mcp-*` (実行中 MCP bridge) を削除候補に含めるクリティカルバグを検出。SKILL.md のデフォルト prefix を `rl-anything-` のみに narrow し、scanner 側に `exclude_patterns` を追加して `claude-\d+` / `claude-mcp-*` を二重保護。userConfig 化の拡張は #71 で追跡
 - **agents: Stop hook を rl-scorer/second-opinion に追加** — CC v2.1.116 で agent frontmatter `hooks:` が `--agent` 経由でも発火するようになったため、`subagent_observe.py` を Stop フックとして追加。main-thread 起動時もテレメトリが記録される
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -72,6 +72,6 @@ Observe hooks (14個, LLMコストゼロ) → テレメトリ JSONL → evolve/d
 
 ## Next
 
-- gstack 改善移植の残り: Agent 3 の cross-project audit を evolve パイプラインに統合（PR #38 で基盤完了、evolve 内での呼び出し統合は次 PR）
+- gstack 改善移植の残り: Agent 3 の cross-project audit は fleet 構想（issue #68）として再設計。観測層を `bin/rl-fleet` で実装する方向で検討中
 - Subagents レイヤーの進化メカニズム（roadmap Phase 3）
 - 6レイヤー全体の自律進化ループ完成（roadmap To-be）

--- a/TODOS.md
+++ b/TODOS.md
@@ -8,6 +8,28 @@
 
 ---
 
+## rl-fleet
+
+### P2
+
+**`resolve_auto_memory_dir` の特殊文字ケーステスト追加（Phase 3 直前）**
+
+**Priority:** P2
+
+fleet.py の `resolve_auto_memory_dir(pj_path) -> Path` ヘルパは、PJ 絶対パスを `~/.claude/projects/<slug>/memory/` に逆引きする。`~/.claude/projects/` の命名規則は `-` 区切り絶対パスだが、PJ パスに日本語・space・記号が含まれる場合の slug 化ロジックは gstack / CC 本体依存。特殊文字ケースが未検証のまま Phase 3 rollback で snapshot / restore に失敗すると、auto-memory の書き戻し事故につながる。
+
+**対応**: Phase 3 実装着手時に以下のテストを追加:
+- `/Users/foo bar/project` (space)
+- `/Users/foo/日本語パス` (multibyte)
+- `/Users/foo/.hidden-dir/sub`
+- シンボリックリンク経由の PJ パス
+
+**背景**: plan-eng-review（2026-04-22, main branch, design 20260422-140954）で senior-engineer agent 相談時に検出。Phase 1/2 では `resolve_auto_memory_dir` 自体が導入されないため、Phase 3 ブランチ起票時に着手で十分。
+
+**依存**: Phase 3 実装開始、`feat/rl-fleet-phase3` ブランチで fleet.py に `resolve_auto_memory_dir` が具体化してから
+
+---
+
 ## philosophy-review
 
 ### P2


### PR DESCRIPTION
## Summary
- **SPEC.md L75 の記載誤り修正**: 「Agent 3 の cross-project audit を evolve パイプラインに統合（PR #38 で基盤完了）」は誤り。PR #38 は実際は v1.15.0 (FileChanged hook + MEMORY.md + userConfig) で cross-project audit とは無関係。fleet 構想 (issue #68) として再設計する旨に修正
- **TODOS.md に rl-fleet Phase 3 TODO 追加**: `resolve_auto_memory_dir` の特殊文字ケーステスト（P2、Phase 3 実装着手時）。office-hours + plan-eng-review (senior-engineer agent 相談) で特定
- **CHANGELOG.md [Unreleased].Fixed に追記**

## 背景
issue #68 で fleet 構想を検討中。その事前タスクとして SPEC.md の誤記載を修正し、plan-eng-review で出た小さな TODO を記録する。fleet 本体実装（DATA_DIR 統一の先行 PR → Phase 1）は後続。

## Test plan
- [x] SPEC.md の L75 修正が意図通りか確認
- [x] TODOS.md のフォーマットが既存エントリに合っているか確認
- [x] CHANGELOG 追記先が [Unreleased].Fixed セクションか確認

Closes #68 の一部（fleet 構想の前段 docs cleanup）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)