### PR TITLE
feat(cleanup): expose cleanup_tmp_prefixes as userConfig (closes #71)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -51,6 +51,12 @@
       "type": "boolean",
       "description": "Show environment growth phase on session start (default: true)",
       "sensitive": false
+    },
+    "cleanup_tmp_prefixes": {
+      "title": "Cleanup Tmp Prefixes",
+      "type": "string",
+      "description": "Comma-separated /tmp prefixes scanned by /rl-anything:cleanup. Defaults to 'rl-anything-' only for safety; claude-<uid> and claude-mcp-* are always excluded by scanner even if re-added (ADR-021).",
+      "sensitive": false
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - **cleanup スキル**: `skills/cleanup/SKILL.md` + `scripts/lib/cleanup_scanner.py` — PR マージ・デプロイ後に残る後片付け（マージ済みローカルブランチ削除・remote refs prune・一時 worktree 削除・一時ディレクトリ削除・関連 Issue close 候補提案・元 PR の Test plan 残件リマインド）を、候補提示→`AskUserQuestion` で個別承認→実行で安全に処理する `/rl-anything:cleanup`。`locked` worktree・現在 checkout 中のブランチ・`main`/`master`/`develop` は削除候補から除外。スキャナは純粋関数 6 本（TDD 24 tests）(closes #69)
+- **cleanup: tmp prefix を userConfig 化** — `manifest.userConfig` に `cleanup_tmp_prefixes` (string, カンマ区切り, default `"rl-anything-"`) を追加。`scripts/lib/cleanup_scanner.py::parse_prefix_config` で string → list 変換（trim / 空要素除去 / 重複排除 / `None` 許容）。SKILL.md は `load_user_config` + `parse_prefix_config` 経由で prefix を取得し、実行時に scan scope を `[cleanup] tmp scan scope: [...]` で宣言表示。scanner 側 `_DEFAULT_TMP_EXCLUDE_PATTERNS` は常時有効なので、ユーザーが `claude-` を再追加しても Claude Code runtime / MCP bridge は保護される (closes #71)
 
 ### Fixed
 - **cleanup scanner: 一時ディレクトリ prefix の危険領域除外** — dogfood (#70) で `scan_tmp_dirs` デフォルト prefix (`claude-` / `gstack-` / `rl-anything-`) が `/tmp/claude-<uid>` (Claude Code runtime) や `/tmp/claude-mcp-*` (実行中 MCP bridge) を削除候補に含めるクリティカルバグを検出。SKILL.md のデフォルト prefix を `rl-anything-` のみに narrow し、scanner 側に `exclude_patterns` を追加して `claude-\d+` / `claude-mcp-*` を二重保護。userConfig 化の拡張は #71 で追跡

--- a/hooks/tests/test_user_config.py
+++ b/hooks/tests/test_user_config.py
@@ -75,3 +75,23 @@ class TestLoadUserConfig:
         assert config["cooldown_hours"] == 48
         assert config["auto_trigger"] is True  # default
         assert config["language"] == "ja"  # default
+
+    def test_cleanup_tmp_prefixes_default(self):
+        """cleanup_tmp_prefixes はデフォルトで "rl-anything-" 単独（安全側）。
+
+        PR #70 dogfood で検出した Claude Code runtime (`/tmp/claude-<uid>`) や
+        MCP bridge (`/tmp/claude-mcp-*`) を削除候補化する wide prefix バグの
+        再発防止として、デフォルトは rl-anything 名前空間のみに絞る。
+        """
+        with mock.patch.dict(os.environ, {}, clear=True):
+            config = common.load_user_config()
+        assert config["cleanup_tmp_prefixes"] == "rl-anything-"
+
+    def test_cleanup_tmp_prefixes_override(self):
+        """cleanup_tmp_prefixes は環境変数で上書き可能（カンマ区切りで複数指定）。"""
+        env = {
+            "CLAUDE_PLUGIN_OPTION_cleanup_tmp_prefixes": "rl-anything-,claude-sandbox-,gstack-scratch-",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            config = common.load_user_config()
+        assert config["cleanup_tmp_prefixes"] == "rl-anything-,claude-sandbox-,gstack-scratch-"

--- a/scripts/lib/cleanup_scanner.py
+++ b/scripts/lib/cleanup_scanner.py
@@ -184,6 +184,31 @@ def extract_issue_numbers_from_branch(name: str) -> list[int]:
 _UNCHECKED_RE = re.compile(r"^\s*-\s*\[\s\]\s+(.+?)\s*$")
 
 
+def parse_prefix_config(value: Optional[str]) -> list[str]:
+    """userConfig の `cleanup_tmp_prefixes` (カンマ区切り文字列) を list に展開する。
+
+    Claude Code の `manifest.userConfig` は boolean/number/string のみサポートする
+    ため、複数 prefix を指定する手段としてカンマ区切り文字列を採用している。この
+    関数は以下を保証する:
+
+    - 各要素の前後空白を trim
+    - 空要素・空白のみ要素は無視
+    - 重複は最初の出現順を保持して排除
+    - `None` や空文字は空 list を返す（呼び出し側で「候補なし」扱いにできる）
+    """
+    if not value or not value.strip():
+        return []
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw in value.split(","):
+        item = raw.strip()
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        ordered.append(item)
+    return ordered
+
+
 def extract_unchecked_testplan(pr_body: Optional[str]) -> list[str]:
     """PR 本文から未チェック `- [ ]` 項目を抽出する。"""
     if not pr_body:

--- a/scripts/lib/rl_common.py
+++ b/scripts/lib/rl_common.py
@@ -39,6 +39,11 @@ USER_CONFIG_DEFAULTS: dict[str, object] = {
     "cooldown_hours": 24,
     "language": "ja",
     "growth_display": True,
+    # cleanup スキル: 一時ディレクトリ削除候補の prefix (カンマ区切り)。
+    # manifest.userConfig は boolean/number/string のみサポートのため string で
+    # 受け取り、scripts/lib/cleanup_scanner.parse_prefix_config で list 化する。
+    # 安全側デフォルト: rl-anything 名前空間のみ (ADR-021)。
+    "cleanup_tmp_prefixes": "rl-anything-",
 }
 
 

--- a/scripts/tests/test_cleanup_scanner.py
+++ b/scripts/tests/test_cleanup_scanner.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(_lib))
 from cleanup_scanner import (
     extract_issue_numbers_from_branch,
     extract_unchecked_testplan,
+    parse_prefix_config,
     scan_merged_branches,
     scan_prunable_remote_refs,
     scan_removable_worktrees,
@@ -221,6 +222,48 @@ def test_scan_tmp_dirs_custom_exclude_patterns(tmp_path):
     )
     names = sorted(os.path.basename(p) for p in result)
     assert names == ["gstack-scratch-ok"]
+
+
+# ---------- parse_prefix_config ----------
+
+def test_parse_prefix_config_single():
+    assert parse_prefix_config("rl-anything-") == ["rl-anything-"]
+
+
+def test_parse_prefix_config_multiple():
+    """カンマ区切りで複数 prefix を受け付ける。"""
+    result = parse_prefix_config("rl-anything-,claude-sandbox-,gstack-scratch-")
+    assert result == ["rl-anything-", "claude-sandbox-", "gstack-scratch-"]
+
+
+def test_parse_prefix_config_trims_whitespace():
+    """各要素前後の空白を除去する（人間が手書きで編集する想定）。"""
+    result = parse_prefix_config(" rl-anything- , claude-sandbox- ")
+    assert result == ["rl-anything-", "claude-sandbox-"]
+
+
+def test_parse_prefix_config_drops_empty_items():
+    """空要素（連続カンマ・前後カンマ）は無視する。"""
+    result = parse_prefix_config(",rl-anything-,,claude-sandbox-,")
+    assert result == ["rl-anything-", "claude-sandbox-"]
+
+
+def test_parse_prefix_config_dedupes_preserving_order():
+    """重複 prefix は最初の出現順を保持して排除する。"""
+    result = parse_prefix_config("rl-anything-,claude-sandbox-,rl-anything-")
+    assert result == ["rl-anything-", "claude-sandbox-"]
+
+
+def test_parse_prefix_config_empty_or_whitespace_returns_empty():
+    """空文字・空白のみは空 list を返す（scan を実質無効化）。"""
+    assert parse_prefix_config("") == []
+    assert parse_prefix_config("   ") == []
+    assert parse_prefix_config(",,,") == []
+
+
+def test_parse_prefix_config_handles_none():
+    """None も空 list にフォールバック（load_user_config が未設定時に None を返す可能性に備える）。"""
+    assert parse_prefix_config(None) == []
 
 
 def test_scan_tmp_dirs_override_exclude_patterns_with_empty_list(tmp_path):

--- a/skills/cleanup/SKILL.md
+++ b/skills/cleanup/SKILL.md
@@ -14,7 +14,7 @@ PR マージ・デプロイ完了後に残る以下の「痕跡」を、**候補
 1. マージ済みローカルブランチの削除
 2. stale な remote tracking branch の prune
 3. 一時 worktree の削除（`locked` は除外）
-4. `/tmp/rl-anything-*` 配下の削除（CRITICAL: `claude-` / `gstack-` はランタイム領域と衝突するためデフォルト対象外。拡張は Issue #71 で userConfig 化予定）
+4. 一時ディレクトリ配下の削除（default: `/tmp/rl-anything-*`。CRITICAL: `claude-` / `gstack-` はランタイム領域と衝突するためデフォルト対象外。`CLAUDE_PLUGIN_OPTION_cleanup_tmp_prefixes` / manifest userConfig でカンマ区切り拡張可能、scanner 側の安全ネット (`claude-<uid>` / `claude-mcp-*` 常時除外) で防御維持）
 5. マージ済みブランチ名から推定した関連 Issue の close 候補提案（**自動 close はしない**）
 6. 元 PR の Test plan 未完了チェックの残件リマインド
 
@@ -28,13 +28,17 @@ PR マージ・デプロイ完了後に残る以下の「痕跡」を、**候補
 
 ```python
 # スキル内から Bash 経由で実行する想定のスニペット
-import json, os, subprocess, sys
-sys.path.insert(0, "scripts/lib")
+import os, subprocess, sys
+from pathlib import Path
+_lib = Path(__file__).resolve().parents[2] / "scripts" / "lib" if "__file__" in dir() else Path("scripts/lib")
+sys.path.insert(0, str(_lib))
 from cleanup_scanner import (
     scan_merged_branches, scan_prunable_remote_refs,
     scan_removable_worktrees, scan_tmp_dirs,
     extract_issue_numbers_from_branch, extract_unchecked_testplan,
+    parse_prefix_config,
 )
+from rl_common import load_user_config
 
 current = subprocess.run(
     ["git", "rev-parse", "--abbrev-ref", "HEAD"],
@@ -45,6 +49,11 @@ main_wt = subprocess.run(
     capture_output=True, text=True
 ).stdout.strip()
 
+cfg = load_user_config()
+tmp_prefixes = parse_prefix_config(cfg.get("cleanup_tmp_prefixes"))
+# 初回に scan scope を宣言（ユーザーが手動設定した prefix を把握できるように）
+print(f"[cleanup] tmp scan scope: {tmp_prefixes or '(none — Category 4 effectively disabled)'}")
+
 merged = scan_merged_branches(
     base_branches=["main"],
     current_branch=current,
@@ -52,7 +61,8 @@ merged = scan_merged_branches(
 )
 prune = scan_prunable_remote_refs()
 worktrees = scan_removable_worktrees(main_worktree_path=main_wt)
-tmp_dirs = scan_tmp_dirs(prefixes=["rl-anything-"])  # narrow default — see CRITICAL note below
+tmp_dirs = scan_tmp_dirs(prefixes=tmp_prefixes) if tmp_prefixes else []
+# scanner 側の _DEFAULT_TMP_EXCLUDE_PATTERNS が `claude-<uid>` / `claude-mcp-*` を常時保護
 ```
 
 **収集結果を一覧表示**してからユーザーに見せる:
@@ -129,7 +139,7 @@ C) Abort
 
 #### カテゴリ 4: 一時ディレクトリ
 
-初版デフォルト prefix は **`rl-anything-` のみ**。`claude-` / `gstack-` は Claude Code ランタイム (`/tmp/claude-<uid>`) や MCP bridge (`/tmp/claude-mcp-*`)、gstack 作業ディレクトリ (`/tmp/gstack-work`) と衝突し、削除するとセッションが壊れる危険があるため**デフォルトから除外**している。なお scanner 側 `_DEFAULT_TMP_EXCLUDE_PATTERNS` で `claude-<uid>` / `claude-mcp-*` は二重に保護している（ユーザー独自拡張時の保険）。prefix 拡張は Issue #71 で userConfig 化予定。
+デフォルト prefix は **`rl-anything-` のみ**。`claude-` / `gstack-` は Claude Code ランタイム (`/tmp/claude-<uid>`) や MCP bridge (`/tmp/claude-mcp-*`)、gstack 作業ディレクトリ (`/tmp/gstack-work`) と衝突し、削除するとセッションが壊れる危険があるため**デフォルトから除外**している。prefix 拡張は `manifest.userConfig` の `cleanup_tmp_prefixes`（またはその環境変数 `CLAUDE_PLUGIN_OPTION_cleanup_tmp_prefixes`）でカンマ区切りで追加可能（例: `"rl-anything-,claude-sandbox-,gstack-scratch-"`）。scanner 側 `_DEFAULT_TMP_EXCLUDE_PATTERNS` で `claude-<uid>` / `claude-mcp-*` は二重に保護しているため、ユーザーが `claude-` prefix を追加してもランタイム領域は守られる。
 
 各ディレクトリについて個別に:
 


### PR DESCRIPTION
## Summary
- Issue #71 対応。\`/rl-anything:cleanup\` カテゴリ4（一時ディレクトリ削除）でスキャンする prefix リストを \`manifest.userConfig\` 経由で拡張可能にする
- 既存の安全側デフォルト（\`rl-anything-\` のみ）は維持、拡張はユーザー opt-in
- scanner 側 \`_DEFAULT_TMP_EXCLUDE_PATTERNS\` の defense-in-depth は常時有効なので、ユーザーが \`claude-\` / \`gstack-\` を再追加しても Claude Code runtime (\`/tmp/claude-<uid>\`) と MCP bridge (\`/tmp/claude-mcp-*\`) は保護される

## 変更内容
- \`.claude-plugin/plugin.json\`: userConfig に \`cleanup_tmp_prefixes\` (string, カンマ区切り, default \`"rl-anything-"\`) 追加
- \`scripts/lib/rl_common.py\`: \`USER_CONFIG_DEFAULTS\` に同キー追加（ADR-021 の安全側デフォルト踏襲）
- \`scripts/lib/cleanup_scanner.py\`: \`parse_prefix_config(value) -> list[str]\` 追加。trim / 空要素除去 / 重複排除 / \`None\` 許容
- \`skills/cleanup/SKILL.md\`: Step 1 スニペットを \`load_user_config\` + \`parse_prefix_config\` 経由に変更。実行時に scan scope を \`[cleanup] tmp scan scope: [...]\` で宣言表示（Issue #71 の提案3）。カテゴリ4 説明も userConfig 経由の拡張手順に更新
- \`CHANGELOG.md\` \`[Unreleased].Added\` に追記

## 使い方
\`\`\`bash
# ユーザーがプロジェクト固有の prefix を追加する場合
export CLAUDE_PLUGIN_OPTION_cleanup_tmp_prefixes=\"rl-anything-,my-project-scratch-\"
\`\`\`
またはインストール時に Claude Code の plugin config UI から設定。

## Test plan
- [x] \`python3 -m pytest hooks/tests/test_user_config.py scripts/tests/test_cleanup_scanner.py -v\` → 38 passed（新規: parse 7 + userConfig 2）
- [x] \`python3 -m pytest hooks/ scripts/tests/ scripts/rl/tests/ -x -q\` → **1551 passed**（リグレッションなし）
- [x] \`claude plugin validate .\` → 既存 warning のみ（scope 外）
- [x] dogfood: env で \`claude-\` を wide prefix として追加し、\`scan_tmp_dirs\` の結果に \`claude-501\` / \`claude-mcp-*\` が含まれないことを実 /tmp 環境で確認済み（runtime leak ゼロ）

closes #71
refs #69 (parent skill), refs #70 (initial implementation + hotfix), ADR-021

🤖 Generated with [Claude Code](https://claude.com/claude-code)