### PR TITLE
chore(release): v1.33.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rl-anything",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "description": "スキル/ルールの直接パッチ最適化と自律進化ループ",
   "author": {
     "name": "min-sys"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.33.0] - 2026-04-22
+
 ### Changed
 - **`scripts/lib/audit.py` の `DATA_DIR` を `rl_common.DATA_DIR` へ統一** — `audit.py:42` でハードコードされていた `DATA_DIR = Path.home() / ".claude" / "rl-anything"` を削除し、`from rl_common import DATA_DIR` に差し替え。`rl_common.py` は既に `CLAUDE_PLUGIN_DATA` env var をサポートしているため、`audit.py` 経由でも fleet 構想（issue #68）で必要な cross-project データ切替が動作するようになる。`bloat_control.py` の `from audit import DATA_DIR` と既存テストの `patch("audit.DATA_DIR", ...)` は再エクスポート (`audit.DATA_DIR is rl_common.DATA_DIR`) によって互換維持。5 tests 追加（env 未設定/env 指定/空文字 fallback/identity/bloat_control 経路）、全 1547 tests pass
 


### PR DESCRIPTION
## Summary
Minor bump (**v1.32.0 → v1.33.0**)。Issue #69 系（cleanup スキル）の完全クローズ + fleet blocker 解消（audit DATA_DIR unify）を含む出荷。

## SemVer 判定

| Type | 件数 | 支配 |
|------|------|------|
| feat | 3 件（cleanup 新設 / userConfig 化 / Stop hook） | **minor** |
| refactor | 1 件（audit DATA_DIR unify） | patch 相当 |
| fix | 3 件（scanner prefix fix / SPEC PR #38 / その他） | patch 相当 |
| docs | 4 件 | 影響なし |

→ **minor (1.33.0)**

## 主要変更

### Added
- 新スキル `/rl-anything:cleanup` — PR マージ・デプロイ後の痕跡を候補提示→個別承認→実行で安全処理（#70, closes #69）
- `cleanup_tmp_prefixes` manifest.userConfig 追加（#76, closes #71）
- Stop hook を rl-scorer/second-opinion agent に追加（CC v2.1.116 対応）

### Changed
- `scripts/lib/audit.py::DATA_DIR` を `rl_common.DATA_DIR` に統一（fleet blocker 解消、#74）

### Fixed
- cleanup scanner の `_DEFAULT_TMP_EXCLUDE_PATTERNS` で `claude-<uid>` / `claude-mcp-*` を二重保護（dogfood で検出した critical バグ、#70 内 hotfix）
- SPEC.md L75 の PR #38 記載誤り訂正（#72）

### Docs (reference)
- ADR-021 (cleanup tmp_dir prefix safety-first default) 新設
- SPEC.md / spec/ に cleanup スキル反映（#73, #78）

## 変更ファイル
- `.claude-plugin/plugin.json`: \`"version": "1.32.0"\` → \`"1.33.0"\`
- `CHANGELOG.md`: `[Unreleased]` を `[1.33.0] - 2026-04-22` に変換、新 `[Unreleased]` を最上位に追加

## Test plan
- [x] plugin.json の JSON 妥当性（明示的に `python3 -c 'import json; json.load(...)'` で確認済み）
- [x] CHANGELOG.md の Unreleased 欄が空で残り、\[1.33.0\] セクションに従来の Unreleased 内容が移っていること
- [x] 未記載変更なし（v1.32.0 以降の 8 コミット全てが CHANGELOG に対応）
- [x] 過去 release の慣習通り `chore(release): v<version>` 形式 + main への squash merge（tag なし、v1.0.x 以降の慣習に合わせる）

refs #69 (closed), #71 (closed), #74, #70, #76 — すべてリリース対象

🤖 Generated with [Claude Code](https://claude.com/claude-code)