### PR TITLE
feat(fleet): Phase 1 — rl-fleet status CLI (refs #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **fleet スキル Phase 1 — `bin/rl-fleet status` CLI**: 全 PJ 横断で rl-anything の健康状態を一覧表示する「4 本目の柱」の基礎実装（issue #68）。`scripts/lib/fleet.py` に 5 つのコア関数を TDD で実装: `enumerate_projects` (`~/matsukaze-utils/*` を `.claude/` or `CLAUDE.md` で絞り込み、ドットディレクトリ除外) / `classify_project` (settings.json `enabledPlugins` + auto-memory 30 日 mtime ハイブリッド 3 値判定 + parse retry) / `run_audit_subprocess` (subprocess で `bin/rl-audit --growth --skip-rescore` 実行、growth-state JSON から env_score/phase/level を取得、TIMEOUT/ERROR 区別) / `format_status_table` (7 列整列 + 相対時刻フォーマット + N/A 表示) / `resolve_auto_memory_dir` (Phase 3 snapshot 準備)。`collect_fleet_status` は `ThreadPoolExecutor(max_workers=2)` で並列化し、STATUS_ENABLED の PJ のみ subprocess audit を呼ぶ最適化。fleet-run 履歴は `<DATA_DIR>/fleet-runs/<ts>.jsonl` に追記。`_DEFAULT_DATA_DIR` は `rl_common.DATA_DIR` を alias し `CLAUDE_PLUGIN_DATA` env を尊重（pre-landing review で発見した silent data mismatch バグを修正）。perf 実測: 7 PJ / 1.05s（設計目標 3s / 6 PJ を大幅クリア）。30 unit tests（refs #68）
+
 ## [1.33.0] - 2026-04-22
 
 ### Changed

--- a/bin/rl-fleet
+++ b/bin/rl-fleet
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""bin/rl-fleet — 全 PJ 横断で rl-anything の状態を一覧する CLI（Phase 1: status のみ）。"""
+import sys
+from pathlib import Path
+
+_lib = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(_lib))
+
+from fleet import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/fleet.py
+++ b/scripts/lib/fleet.py
@@ -4,7 +4,62 @@
 """
 from __future__ import annotations
 
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
+
+STATUS_ENABLED = "ENABLED"
+STATUS_STALE = "STALE"
+STATUS_NOT_ENABLED = "NOT_ENABLED"
+
+AUDIT_OK = "OK"
+AUDIT_TIMEOUT = "TIMEOUT"
+AUDIT_ERROR = "ERROR"
+
+_DEFAULT_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+_DEFAULT_AUTO_MEMORY_ROOT = Path.home() / ".claude" / "projects"
+_DEFAULT_DATA_DIR = Path.home() / ".claude" / "rl-anything"
+_DEFAULT_RL_AUDIT_BIN = Path(__file__).resolve().parent.parent.parent / "bin" / "rl-audit"
+_PLUGIN_KEY_PREFIX = "rl-anything@"
+_SETTINGS_RETRY_SLEEP_SEC = 0.1
+
+
+@dataclass
+class AuditResult:
+    """PJ audit の結果（TIMEOUT/ERROR 区別付き）。"""
+
+    status: str  # AUDIT_OK | AUDIT_TIMEOUT | AUDIT_ERROR
+    env_score: float | None = None
+    phase: str | None = None
+    growth_level: int | None = None
+    latest_audit: datetime | None = None
+    message: str = ""
+
+
+@dataclass
+class FleetRow:
+    """fleet status 表示 1 行分。"""
+
+    pj_name: str
+    status: str  # STATUS_ENABLED / STATUS_STALE / STATUS_NOT_ENABLED
+    env_score: float | None = None
+    growth_level: int | None = None
+    phase: str | None = None
+    latest_audit: datetime | None = None
+    audit_status: str = AUDIT_OK
+    message: str = ""
+
+
+def _pj_safe_name(pj_path: Path) -> str:
+    """growth-state cache 命名に使う safe_name（growth_engine._cache_path と同じルール）。"""
+    name = pj_path.resolve().name or "unknown"
+    return re.sub(r"[^a-zA-Z0-9_\-]", "_", name)
 
 
 def enumerate_projects(root: Path) -> list[Path]:
@@ -27,6 +82,237 @@ def enumerate_projects(root: Path) -> list[Path]:
         if (child / ".claude").is_dir() or (child / "CLAUDE.md").is_file():
             projects.append(child)
     return projects
+
+
+def _load_settings_with_retry(settings_path: Path) -> dict | None:
+    """settings.json を読んで dict を返す。parse 失敗時は 100ms 後に 1 回 retry。"""
+    for attempt in range(2):
+        if not settings_path.is_file():
+            return None
+        try:
+            return json.loads(settings_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            if attempt == 0:
+                time.sleep(_SETTINGS_RETRY_SLEEP_SEC)
+                continue
+            return None
+    return None
+
+
+def _is_plugin_enabled(settings: dict) -> bool:
+    """settings.enabledPlugins に rl-anything@* が truthy で含まれるか。"""
+    enabled = settings.get("enabledPlugins") or {}
+    if not isinstance(enabled, dict):
+        return False
+    for key, value in enabled.items():
+        if key.startswith(_PLUGIN_KEY_PREFIX) and bool(value):
+            return True
+    return False
+
+
+def _latest_activity(auto_memory_dir: Path) -> float | None:
+    """auto-memory ディレクトリ内の `.jsonl` の最新 mtime を返す。無ければ None。"""
+    if not auto_memory_dir.is_dir():
+        return None
+    latest: float | None = None
+    for f in auto_memory_dir.glob("*.jsonl"):
+        try:
+            mtime = f.stat().st_mtime
+        except OSError:
+            continue
+        if latest is None or mtime > latest:
+            latest = mtime
+    return latest
+
+
+def classify_project(
+    pj_path: Path,
+    settings_path: Path | None = None,
+    auto_memory_root: Path | None = None,
+    stale_days: int = 30,
+    now: datetime | None = None,
+) -> str:
+    """PJ の rl-anything 導入状況を 3 値で判定する。
+
+    判定表 (設計 Phase 1 ハイブリッド):
+    - `rl-anything@*` 有効 + auto-memory の直近 `.jsonl` が `stale_days` 以内 → ENABLED
+    - `rl-anything@*` 有効 + auto-memory 古い or 欠損 → STALE
+    - `rl-anything@*` 無効 or settings 欠損 / 破損（retry も失敗） → NOT_ENABLED
+
+    `settings_path` が破損していた場合は 100ms sleep 後に 1 回だけ retry する。
+    """
+    settings_path = settings_path or _DEFAULT_SETTINGS_PATH
+    auto_memory_root = auto_memory_root or _DEFAULT_AUTO_MEMORY_ROOT
+    now = now or datetime.now(timezone.utc)
+
+    settings = _load_settings_with_retry(settings_path)
+    if settings is None or not _is_plugin_enabled(settings):
+        return STATUS_NOT_ENABLED
+
+    slug = str(pj_path.resolve()).replace("/", "-")
+    auto_memory_dir = auto_memory_root / slug
+
+    latest = _latest_activity(auto_memory_dir)
+    if latest is None:
+        return STATUS_STALE
+    age_sec = now.timestamp() - latest
+    if age_sec > stale_days * 86400:
+        return STATUS_STALE
+    return STATUS_ENABLED
+
+
+def run_audit_subprocess(
+    pj_path: Path,
+    timeout: float = 10.0,
+    data_dir: Path | None = None,
+    rl_audit_bin: Path | None = None,
+) -> AuditResult:
+    """PJ の audit を subprocess で実行し growth-state から結果を読み取る。
+
+    - `bin/rl-audit <pj_path> --growth --skip-rescore` を実行（副作用: growth-state 更新）
+    - `data_dir` 指定時は `CLAUDE_PLUGIN_DATA=<data_dir>` を env に設定
+    - subprocess timeout / returncode 非ゼロ / growth-state 破損は `AuditResult.status` で区別
+
+    Phase 1 では rl-audit stdout は parse せず growth-state JSON を唯一の真実とする。
+    """
+    rl_audit_bin = rl_audit_bin or _DEFAULT_RL_AUDIT_BIN
+    effective_data_dir = data_dir or _DEFAULT_DATA_DIR
+    cmd = [sys.executable, str(rl_audit_bin), str(pj_path), "--growth", "--skip-rescore"]
+    env = os.environ.copy()
+    if data_dir is not None:
+        env["CLAUDE_PLUGIN_DATA"] = str(data_dir)
+
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, env=env
+        )
+    except subprocess.TimeoutExpired:
+        return AuditResult(AUDIT_TIMEOUT, message=f"timeout after {timeout}s")
+    except OSError as e:
+        return AuditResult(AUDIT_ERROR, message=f"spawn failed: {e}")
+
+    if proc.returncode != 0:
+        stderr_tail = (proc.stderr or "").strip().splitlines()
+        tail = stderr_tail[-1] if stderr_tail else f"returncode {proc.returncode}"
+        return AuditResult(AUDIT_ERROR, message=tail[:200])
+
+    state_path = effective_data_dir / f"growth-state-{_pj_safe_name(pj_path)}.json"
+    if not state_path.is_file():
+        return AuditResult(AUDIT_OK, message="no growth-state cache")
+    try:
+        state = json.loads(state_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        return AuditResult(AUDIT_ERROR, message=f"state parse: {e}")
+
+    env_score = state.get("progress")
+    phase = state.get("phase")
+    growth_level = _safe_compute_level(env_score)
+    latest_audit = _parse_iso(state.get("updated_at"))
+    return AuditResult(
+        status=AUDIT_OK,
+        env_score=env_score if isinstance(env_score, (int, float)) else None,
+        phase=phase if isinstance(phase, str) else None,
+        growth_level=growth_level,
+        latest_audit=latest_audit,
+    )
+
+
+def _safe_compute_level(env_score: object) -> int | None:
+    if not isinstance(env_score, (int, float)):
+        return None
+    try:
+        from growth_level import compute_level
+    except ImportError:
+        return None
+    return compute_level(float(env_score)).level
+
+
+_TABLE_HEADERS = ["PJ", "STATUS", "SCORE", "LV", "PHASE", "LAST_AUDIT", "AUDIT"]
+
+
+def _format_relative(dt: datetime, now: datetime) -> str:
+    """`1h ago` / `3d ago` のような短い相対時刻表記。"""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = now - dt
+    seconds = int(delta.total_seconds())
+    if seconds < 0:
+        return "future"
+    minutes = seconds // 60
+    hours = minutes // 60
+    days = hours // 24
+    if days >= 1:
+        return f"{days}d ago"
+    if hours >= 1:
+        return f"{hours}h ago"
+    if minutes >= 1:
+        return f"{minutes}m ago"
+    return "just now"
+
+
+def _format_cell_score(row: FleetRow) -> str:
+    if row.status != STATUS_ENABLED:
+        return "N/A"
+    if row.env_score is None:
+        return "—"
+    return f"{row.env_score:.2f}"
+
+
+def _format_cell_level(row: FleetRow) -> str:
+    if row.growth_level is None:
+        return "—"
+    return f"Lv.{row.growth_level}"
+
+
+def _format_cell_phase(row: FleetRow) -> str:
+    return row.phase or "—"
+
+
+def _format_cell_last_audit(row: FleetRow, now: datetime) -> str:
+    if row.latest_audit is None:
+        return "—"
+    return _format_relative(row.latest_audit, now)
+
+
+def _format_cell_audit(row: FleetRow) -> str:
+    if row.status == STATUS_NOT_ENABLED:
+        return "—"
+    return row.audit_status
+
+
+def format_status_table(rows: list[FleetRow], now: datetime | None = None) -> str:
+    """fleet status 行を整列済みテキストテーブルに整形する。
+
+    列: PJ / STATUS / SCORE / LV / PHASE / LAST_AUDIT / AUDIT
+    列幅は各列の最大値に合わせ、各セルは左詰め（英数字のみ想定）。
+    """
+    now = now or datetime.now(timezone.utc)
+    cells: list[list[str]] = [list(_TABLE_HEADERS)]
+    for row in rows:
+        cells.append([
+            row.pj_name,
+            row.status,
+            _format_cell_score(row),
+            _format_cell_level(row),
+            _format_cell_phase(row),
+            _format_cell_last_audit(row, now),
+            _format_cell_audit(row),
+        ])
+    widths = [max(len(c) for c in col) for col in zip(*cells)]
+    lines = []
+    for row_cells in cells:
+        parts = [row_cells[i].ljust(widths[i]) for i in range(len(widths))]
+        lines.append("  ".join(parts).rstrip())
+    return "\n".join(lines) + "\n"
+
+
+def _parse_iso(ts: object) -> datetime | None:
+    if not isinstance(ts, str):
+        return None
+    try:
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        return None
 
 
 def resolve_auto_memory_dir(pj_path: Path) -> Path:

--- a/scripts/lib/fleet.py
+++ b/scripts/lib/fleet.py
@@ -8,6 +8,7 @@ import argparse
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -30,11 +31,22 @@ _DEFAULT_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 _DEFAULT_AUTO_MEMORY_ROOT = Path.home() / ".claude" / "projects"
 _DEFAULT_MATSUKAZE_ROOT = Path.home() / "matsukaze-utils"
 _DEFAULT_RL_AUDIT_BIN = Path(__file__).resolve().parent.parent.parent / "bin" / "rl-audit"
-_DEFAULT_FLEET_RUNS_DIR = _DEFAULT_DATA_DIR / "fleet-runs"
 _PLUGIN_KEY_PREFIX = "rl-anything@"
 _SETTINGS_RETRY_SLEEP_SEC = 0.1
 _DEFAULT_TIMEOUT_SEC = 10.0
 _DEFAULT_MAX_WORKERS = 2
+_KILL_GRACE_SEC = 2.0
+
+
+def _current_data_dir() -> Path:
+    """CLAUDE_PLUGIN_DATA を呼び出し時に再参照して DATA_DIR を返す。
+
+    `rl_common._DEFAULT_DATA_DIR` は import-time capture のため env 後追い変更を
+    反映できない。fleet-runs 書き出しなど呼び出しタイミングが重要な処理では
+    こちらを使う。
+    """
+    env_val = os.environ.get("CLAUDE_PLUGIN_DATA", "")
+    return Path(env_val) if env_val else Path.home() / ".claude" / "rl-anything"
 
 
 @dataclass
@@ -91,7 +103,10 @@ def enumerate_projects(root: Path) -> list[Path]:
     - `.claude/` ディレクトリ
     - `CLAUDE.md` ファイル
 
-    ドットで始まるディレクトリ (`.worktrees/` 等) は開発メタデータのため除外。
+    除外ルール:
+    - ドットで始まるディレクトリ (`.worktrees/` 等) は開発メタデータのため
+    - シンボリックリンクは任意パスへの audit trampoline を防ぐため
+
     `root` 自体が存在しない場合は空リストを返す。
     返り値はディレクトリ名でソート。
     """
@@ -99,7 +114,7 @@ def enumerate_projects(root: Path) -> list[Path]:
         return []
     projects: list[Path] = []
     for child in sorted(root.iterdir(), key=lambda p: p.name):
-        if not child.is_dir() or child.name.startswith("."):
+        if not child.is_dir() or child.name.startswith(".") or child.is_symlink():
             continue
         if (child / ".claude").is_dir() or (child / "CLAUDE.md").is_file():
             projects.append(child)
@@ -190,30 +205,48 @@ def run_audit_subprocess(
 ) -> AuditResult:
     """PJ の audit を subprocess で実行し growth-state から結果を読み取る。
 
-    - `bin/rl-audit <pj_path> --growth --skip-rescore` を実行（副作用: growth-state 更新）
+    - `bin/rl-audit --growth --skip-rescore -- <pj_path>` を実行（副作用: growth-state 更新）
+    - `--` 区切りで PJ パスに leading `-` があっても argparse を誤動作させない
     - `data_dir` 指定時は `CLAUDE_PLUGIN_DATA=<data_dir>` を env に設定
+    - subprocess は `start_new_session=True` で別プロセスグループに隔離し、timeout 時は
+      `os.killpg` で子孫まで確実に終了させる（孤児化した rl-audit 子孫が growth-state を
+      半書き状態で残すことを防ぐ）
     - subprocess timeout / returncode 非ゼロ / growth-state 破損は `AuditResult.status` で区別
 
     Phase 1 では rl-audit stdout は parse せず growth-state JSON を唯一の真実とする。
     """
     rl_audit_bin = rl_audit_bin or _DEFAULT_RL_AUDIT_BIN
     effective_data_dir = data_dir or _DEFAULT_DATA_DIR
-    cmd = [sys.executable, str(rl_audit_bin), str(pj_path), "--growth", "--skip-rescore"]
+    # flags を positional より前に置き `--` で区切る → PJ 名が `-` で始まっても安全
+    cmd = [
+        sys.executable, str(rl_audit_bin),
+        "--growth", "--skip-rescore",
+        "--", str(pj_path),
+    ]
     env = os.environ.copy()
     if data_dir is not None:
         env["CLAUDE_PLUGIN_DATA"] = str(data_dir)
 
     try:
-        proc = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=timeout, env=env
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+            start_new_session=True,  # 別プロセスグループ → killpg 可能
         )
-    except subprocess.TimeoutExpired:
-        return AuditResult(AUDIT_TIMEOUT, message=f"timeout after {timeout}s")
     except OSError as e:
         return AuditResult(AUDIT_ERROR, message=f"spawn failed: {e}")
 
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _terminate_process_group(proc)
+        return AuditResult(AUDIT_TIMEOUT, message=f"timeout after {timeout}s")
+
     if proc.returncode != 0:
-        stderr_tail = (proc.stderr or "").strip().splitlines()
+        stderr_tail = (stderr or "").strip().splitlines()
         tail = stderr_tail[-1] if stderr_tail else f"returncode {proc.returncode}"
         return AuditResult(AUDIT_ERROR, message=tail[:200])
 
@@ -236,6 +269,28 @@ def run_audit_subprocess(
         growth_level=growth_level,
         latest_audit=latest_audit,
     )
+
+
+def _terminate_process_group(proc: subprocess.Popen) -> None:
+    """subprocess のプロセスグループを SIGTERM→SIGKILL で順次停止させる。
+
+    `start_new_session=True` で起動した子プロセスは別セッション/PGID を持つので、
+    `os.killpg` で子孫まとめて落とせる。
+    """
+    try:
+        pgid = os.getpgid(proc.pid)
+    except OSError:
+        pgid = proc.pid
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except OSError:
+            break
+        try:
+            proc.wait(timeout=_KILL_GRACE_SEC)
+            return
+        except subprocess.TimeoutExpired:
+            continue
 
 
 def _safe_compute_level(env_score: object) -> int | None:
@@ -351,6 +406,20 @@ def _collect_single(
     )
 
 
+def _find_duplicate_basenames(projects: list[Path]) -> set[str]:
+    """同一 basename を持つ PJ を検出し、重複 basename 集合を返す。
+
+    rl-audit の growth-state cache (`growth-state-<basename>.json`) は basename 単位で
+    命名されるため、同じ basename の PJ が複数あると cache が衝突し fleet は誤った
+    score を表示する。Phase 1 では該当 PJ を AUDIT_ERROR として surface する。
+    Phase 3 の per-PJ CLAUDE_PLUGIN_DATA 分離で根本解決予定。
+    """
+    seen: dict[str, int] = {}
+    for pj in projects:
+        seen[pj.name] = seen.get(pj.name, 0) + 1
+    return {name for name, count in seen.items() if count > 1}
+
+
 def collect_fleet_status(
     root: Path | None = None,
     settings_path: Path | None = None,
@@ -363,6 +432,9 @@ def collect_fleet_status(
 
     STATUS_ENABLED の PJ のみ subprocess audit を走らせる（STALE/NOT_ENABLED は
     低コストで判定のみ）。並列度は ThreadPoolExecutor(max_workers)。
+
+    同じ basename の PJ が複数ある場合は growth-state cache が衝突するため、
+    該当 PJ を AUDIT_ERROR 扱いにして誤ったスコア表示を防ぐ。
     """
     root = root or _DEFAULT_MATSUKAZE_ROOT
     settings_path = settings_path or _DEFAULT_SETTINGS_PATH
@@ -370,8 +442,17 @@ def collect_fleet_status(
     projects = enumerate_projects(root)
     if not projects:
         return []
+    dup_basenames = _find_duplicate_basenames(projects)
 
     def _work(pj: Path) -> FleetRow:
+        if pj.name in dup_basenames:
+            status = classify_project(pj, settings_path, auto_memory_root)
+            return FleetRow(
+                pj_name=pj.name,
+                status=status,
+                audit_status=AUDIT_ERROR,
+                message="duplicate basename (cache would collide)",
+            )
         return _collect_single(
             pj,
             settings_path=settings_path,
@@ -396,8 +477,13 @@ def write_fleet_run(
     fleet_runs_dir: Path | None = None,
     now: datetime | None = None,
 ) -> Path:
-    """fleet-run を `<dir>/<ts>.jsonl` に追記する。各行は 1 PJ の状態。"""
-    fleet_runs_dir = fleet_runs_dir or _DEFAULT_FLEET_RUNS_DIR
+    """fleet-run を `<dir>/<ts>.jsonl` に追記する。各行は 1 PJ の状態。
+
+    `fleet_runs_dir` 未指定時は呼び出し時点の `CLAUDE_PLUGIN_DATA` を再参照して
+    `<data_dir>/fleet-runs/` を使う（import-time capture で stale 化しない）。
+    """
+    if fleet_runs_dir is None:
+        fleet_runs_dir = _current_data_dir() / "fleet-runs"
     now = now or datetime.now(timezone.utc)
     fleet_runs_dir.mkdir(parents=True, exist_ok=True)
     stamp = now.strftime("%Y%m%dT%H%M%SZ")

--- a/scripts/lib/fleet.py
+++ b/scripts/lib/fleet.py
@@ -1,0 +1,44 @@
+"""rl-anything fleet — 全 PJ 横断のメンテナンス拠点（Phase 1: status のみ）。
+
+設計: `matsukaze-takashi-main-design-20260422-140954.md` Phase 1 節。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def enumerate_projects(root: Path) -> list[Path]:
+    """PJ 候補を列挙する。
+
+    `root` 直下の子ディレクトリで、以下いずれかを持つものを PJ とみなす:
+    - `.claude/` ディレクトリ
+    - `CLAUDE.md` ファイル
+
+    ドットで始まるディレクトリ (`.worktrees/` 等) は開発メタデータのため除外。
+    `root` 自体が存在しない場合は空リストを返す。
+    返り値はディレクトリ名でソート。
+    """
+    if not root.is_dir():
+        return []
+    projects: list[Path] = []
+    for child in sorted(root.iterdir(), key=lambda p: p.name):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        if (child / ".claude").is_dir() or (child / "CLAUDE.md").is_file():
+            projects.append(child)
+    return projects
+
+
+def resolve_auto_memory_dir(pj_path: Path) -> Path:
+    """PJ パスから Claude Code auto-memory ディレクトリを逆引きする。
+
+    命名規則: `~/.claude/projects/-<絶対パスを `/` → `-` に置換>`
+
+    例: `/Users/foo/bar` → `~/.claude/projects/-Users-foo-bar`
+
+    相対パスや trailing slash は `Path.resolve()` で正規化してから変換する。
+    特殊文字 (`-` を含むディレクトリ名等) は Phase 3 で扱う (本実装は非対応)。
+    """
+    absolute = pj_path.resolve()
+    slug = str(absolute).replace("/", "-")
+    return Path.home() / ".claude" / "projects" / slug

--- a/scripts/lib/fleet.py
+++ b/scripts/lib/fleet.py
@@ -4,13 +4,15 @@
 """
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -25,9 +27,13 @@ AUDIT_ERROR = "ERROR"
 _DEFAULT_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 _DEFAULT_AUTO_MEMORY_ROOT = Path.home() / ".claude" / "projects"
 _DEFAULT_DATA_DIR = Path.home() / ".claude" / "rl-anything"
+_DEFAULT_MATSUKAZE_ROOT = Path.home() / "matsukaze-utils"
 _DEFAULT_RL_AUDIT_BIN = Path(__file__).resolve().parent.parent.parent / "bin" / "rl-audit"
+_DEFAULT_FLEET_RUNS_DIR = _DEFAULT_DATA_DIR / "fleet-runs"
 _PLUGIN_KEY_PREFIX = "rl-anything@"
 _SETTINGS_RETRY_SLEEP_SEC = 0.1
+_DEFAULT_TIMEOUT_SEC = 10.0
+_DEFAULT_MAX_WORKERS = 2
 
 
 @dataclass
@@ -306,6 +312,113 @@ def format_status_table(rows: list[FleetRow], now: datetime | None = None) -> st
     return "\n".join(lines) + "\n"
 
 
+def _collect_single(
+    pj_path: Path,
+    *,
+    settings_path: Path,
+    auto_memory_root: Path,
+    data_dir: Path | None,
+    timeout: float,
+) -> FleetRow:
+    status = classify_project(pj_path, settings_path, auto_memory_root)
+    if status != STATUS_ENABLED:
+        return FleetRow(pj_name=pj_path.name, status=status)
+    audit = run_audit_subprocess(pj_path, timeout=timeout, data_dir=data_dir)
+    return FleetRow(
+        pj_name=pj_path.name,
+        status=status,
+        env_score=audit.env_score,
+        growth_level=audit.growth_level,
+        phase=audit.phase,
+        latest_audit=audit.latest_audit,
+        audit_status=audit.status,
+        message=audit.message,
+    )
+
+
+def collect_fleet_status(
+    root: Path | None = None,
+    settings_path: Path | None = None,
+    auto_memory_root: Path | None = None,
+    data_dir: Path | None = None,
+    timeout: float = _DEFAULT_TIMEOUT_SEC,
+    max_workers: int = _DEFAULT_MAX_WORKERS,
+) -> list[FleetRow]:
+    """全 PJ の fleet ステータスを並列収集して行リストを返す。
+
+    STATUS_ENABLED の PJ のみ subprocess audit を走らせる（STALE/NOT_ENABLED は
+    低コストで判定のみ）。並列度は ThreadPoolExecutor(max_workers)。
+    """
+    root = root or _DEFAULT_MATSUKAZE_ROOT
+    settings_path = settings_path or _DEFAULT_SETTINGS_PATH
+    auto_memory_root = auto_memory_root or _DEFAULT_AUTO_MEMORY_ROOT
+    projects = enumerate_projects(root)
+    if not projects:
+        return []
+
+    def _work(pj: Path) -> FleetRow:
+        return _collect_single(
+            pj,
+            settings_path=settings_path,
+            auto_memory_root=auto_memory_root,
+            data_dir=data_dir,
+            timeout=timeout,
+        )
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        return list(pool.map(_work, projects))
+
+
+def _serialize_row(row: FleetRow) -> dict:
+    d = asdict(row)
+    if row.latest_audit is not None:
+        d["latest_audit"] = row.latest_audit.isoformat()
+    return d
+
+
+def write_fleet_run(
+    rows: list[FleetRow],
+    fleet_runs_dir: Path | None = None,
+    now: datetime | None = None,
+) -> Path:
+    """fleet-run を `<dir>/<ts>.jsonl` に追記する。各行は 1 PJ の状態。"""
+    fleet_runs_dir = fleet_runs_dir or _DEFAULT_FLEET_RUNS_DIR
+    now = now or datetime.now(timezone.utc)
+    fleet_runs_dir.mkdir(parents=True, exist_ok=True)
+    stamp = now.strftime("%Y%m%dT%H%M%SZ")
+    path = fleet_runs_dir / f"{stamp}.jsonl"
+    with path.open("a", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(_serialize_row(row), ensure_ascii=False) + "\n")
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    """`bin/rl-fleet` エントリポイント。"""
+    parser = argparse.ArgumentParser(
+        prog="rl-fleet",
+        description="全 PJ 横断で rl-anything の健康状態を一覧表示する（Phase 1）",
+    )
+    sub = parser.add_subparsers(dest="command")
+    status_p = sub.add_parser("status", help="各 PJ のステータスを表形式で表示（default）")
+    for p in (parser, status_p):
+        p.add_argument("--root", type=Path, default=None, help="PJ 列挙のルート (default: ~/matsukaze-utils)")
+        p.add_argument("--timeout", type=float, default=_DEFAULT_TIMEOUT_SEC, help="PJ 毎の audit タイムアウト秒 (default: 10)")
+        p.add_argument("--max-workers", type=int, default=_DEFAULT_MAX_WORKERS, help="並列数 (default: 2)")
+        p.add_argument("--no-write", action="store_true", help="fleet-runs/*.jsonl への追記をスキップ")
+    args = parser.parse_args(argv)
+
+    rows = collect_fleet_status(
+        root=args.root,
+        timeout=args.timeout,
+        max_workers=args.max_workers,
+    )
+    print(format_status_table(rows), end="")
+    if not args.no_write:
+        write_fleet_run(rows)
+    return 0
+
+
 def _parse_iso(ts: object) -> datetime | None:
     if not isinstance(ts, str):
         return None
@@ -313,6 +426,10 @@ def _parse_iso(ts: object) -> datetime | None:
         return datetime.fromisoformat(ts)
     except ValueError:
         return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
 
 
 def resolve_auto_memory_dir(pj_path: Path) -> Path:

--- a/scripts/lib/fleet.py
+++ b/scripts/lib/fleet.py
@@ -24,9 +24,10 @@ AUDIT_OK = "OK"
 AUDIT_TIMEOUT = "TIMEOUT"
 AUDIT_ERROR = "ERROR"
 
+from rl_common import DATA_DIR as _DEFAULT_DATA_DIR  # honors CLAUDE_PLUGIN_DATA
+
 _DEFAULT_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 _DEFAULT_AUTO_MEMORY_ROOT = Path.home() / ".claude" / "projects"
-_DEFAULT_DATA_DIR = Path.home() / ".claude" / "rl-anything"
 _DEFAULT_MATSUKAZE_ROOT = Path.home() / "matsukaze-utils"
 _DEFAULT_RL_AUDIT_BIN = Path(__file__).resolve().parent.parent.parent / "bin" / "rl-audit"
 _DEFAULT_FLEET_RUNS_DIR = _DEFAULT_DATA_DIR / "fleet-runs"
@@ -68,6 +69,21 @@ def _pj_safe_name(pj_path: Path) -> str:
     return re.sub(r"[^a-zA-Z0-9_\-]", "_", name)
 
 
+def resolve_auto_memory_dir(pj_path: Path) -> Path:
+    """PJ パスから Claude Code auto-memory ディレクトリを逆引きする。
+
+    命名規則: `~/.claude/projects/-<絶対パスを `/` → `-` に置換>`
+
+    例: `/Users/foo/bar` → `~/.claude/projects/-Users-foo-bar`
+
+    相対パスや trailing slash は `Path.resolve()` で正規化してから変換する。
+    特殊文字 (`-` を含むディレクトリ名等) は Phase 3 で扱う (本実装は非対応)。
+    """
+    absolute = pj_path.resolve()
+    slug = str(absolute).replace("/", "-")
+    return Path.home() / ".claude" / "projects" / slug
+
+
 def enumerate_projects(root: Path) -> list[Path]:
     """PJ 候補を列挙する。
 
@@ -102,7 +118,6 @@ def _load_settings_with_retry(settings_path: Path) -> dict | None:
                 time.sleep(_SETTINGS_RETRY_SLEEP_SEC)
                 continue
             return None
-    return None
 
 
 def _is_plugin_enabled(settings: dict) -> bool:
@@ -430,18 +445,3 @@ def _parse_iso(ts: object) -> datetime | None:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
-
-def resolve_auto_memory_dir(pj_path: Path) -> Path:
-    """PJ パスから Claude Code auto-memory ディレクトリを逆引きする。
-
-    命名規則: `~/.claude/projects/-<絶対パスを `/` → `-` に置換>`
-
-    例: `/Users/foo/bar` → `~/.claude/projects/-Users-foo-bar`
-
-    相対パスや trailing slash は `Path.resolve()` で正規化してから変換する。
-    特殊文字 (`-` を含むディレクトリ名等) は Phase 3 で扱う (本実装は非対応)。
-    """
-    absolute = pj_path.resolve()
-    slug = str(absolute).replace("/", "-")
-    return Path.home() / ".claude" / "projects" / slug

--- a/scripts/lib/tests/test_fleet.py
+++ b/scripts/lib/tests/test_fleet.py
@@ -1,0 +1,83 @@
+"""fleet モジュールのユニットテスト。
+
+Phase 1 で必須の 5 関数をカバー:
+- resolve_auto_memory_dir
+- enumerate_projects
+- classify_project
+- run_audit_subprocess
+- format_status_table
+
+特殊文字を含むパスは Phase 3 で扱う（本テストは扱わない）。
+"""
+
+import sys
+from pathlib import Path
+
+_plugin_root = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_plugin_root / "scripts" / "lib"))
+
+from fleet import enumerate_projects, resolve_auto_memory_dir  # noqa: E402
+
+
+class TestResolveAutoMemoryDir:
+    """resolve_auto_memory_dir() の命名規則逆引きテスト。"""
+
+    def test_通常のPJパス(self):
+        pj = Path("/Users/foo/matsukaze-utils/bots")
+        result = resolve_auto_memory_dir(pj)
+        assert result == Path.home() / ".claude" / "projects" / "-Users-foo-matsukaze-utils-bots"
+
+    def test_実測_rl_anything_PJ(self):
+        """~/.claude/projects/ 内に実在するはずの slug と一致する。"""
+        pj = Path("/Users/matsukaze-takashi/matsukaze-utils/rl-anything")
+        result = resolve_auto_memory_dir(pj)
+        expected = Path.home() / ".claude" / "projects" / "-Users-matsukaze-takashi-matsukaze-utils-rl-anything"
+        assert result == expected
+
+    def test_trailing_slash_正規化(self):
+        """末尾スラッシュは除去されて同じ結果になる。"""
+        with_slash = Path("/Users/foo/bar/")
+        without_slash = Path("/Users/foo/bar")
+        assert resolve_auto_memory_dir(with_slash) == resolve_auto_memory_dir(without_slash)
+
+    def test_相対パスは絶対化される(self):
+        """相対パスを渡されたら resolve して絶対パスに揃える。"""
+        rel = Path("./somewhere")
+        result = resolve_auto_memory_dir(rel)
+        # resolve した absolute path が `-` 区切りで slug 化されている
+        abs_str = str(rel.resolve())
+        expected = Path.home() / ".claude" / "projects" / abs_str.replace("/", "-")
+        assert result == expected
+
+
+class TestEnumerateProjects:
+    """enumerate_projects() の PJ 列挙フィルタテスト。"""
+
+    def test_両方持ちとCLAUDE_md単体と_claude_単体を含み両方無しを除外(self, tmp_path):
+        (tmp_path / "both" / ".claude").mkdir(parents=True)
+        (tmp_path / "both" / "CLAUDE.md").write_text("")
+        (tmp_path / "claude_md_only" / "CLAUDE.md").parent.mkdir()
+        (tmp_path / "claude_md_only" / "CLAUDE.md").write_text("")
+        (tmp_path / "dot_claude_only" / ".claude").mkdir(parents=True)
+        (tmp_path / "neither").mkdir()
+        result = enumerate_projects(tmp_path)
+        names = [p.name for p in result]
+        assert names == ["both", "claude_md_only", "dot_claude_only"]
+
+    def test_rootが存在しなければ空リスト(self, tmp_path):
+        missing = tmp_path / "does_not_exist"
+        assert enumerate_projects(missing) == []
+
+    def test_ファイルは除外_子ディレクトリのみ対象(self, tmp_path):
+        (tmp_path / "pj" / ".claude").mkdir(parents=True)
+        (tmp_path / "CLAUDE.md").write_text("")  # root 直下のファイルは対象外
+        result = enumerate_projects(tmp_path)
+        assert [p.name for p in result] == ["pj"]
+
+    def test_ドットディレクトリは除外(self, tmp_path):
+        """`.worktrees` のようなドットディレクトリは PJ 候補にしない。"""
+        (tmp_path / ".worktrees" / ".claude").mkdir(parents=True)
+        (tmp_path / "pj" / "CLAUDE.md").parent.mkdir()
+        (tmp_path / "pj" / "CLAUDE.md").write_text("")
+        result = enumerate_projects(tmp_path)
+        assert [p.name for p in result] == ["pj"]

--- a/scripts/lib/tests/test_fleet.py
+++ b/scripts/lib/tests/test_fleet.py
@@ -105,6 +105,19 @@ class TestEnumerateProjects:
         result = enumerate_projects(tmp_path)
         assert [p.name for p in result] == ["pj"]
 
+    def test_symlinkは除外(self, tmp_path):
+        """PJ ディレクトリへの symlink は任意パスの audit trampoline 防止のため除外。"""
+        root = tmp_path / "root"
+        root.mkdir()
+        real_pj = root / "real_pj"
+        (real_pj / ".claude").mkdir(parents=True)
+        outside = tmp_path / "outside"  # root の外に置く
+        (outside / ".claude").mkdir(parents=True)
+        link = root / "linked_pj"
+        link.symlink_to(outside)
+        result = enumerate_projects(root)
+        assert [p.name for p in result] == ["real_pj"]
+
 
 class TestClassifyProject:
     """classify_project() の 3 値判定 + settings parse retry テスト。"""
@@ -206,6 +219,29 @@ class TestClassifyProject:
         assert classify_project(pj, settings, auto_memory) == STATUS_NOT_ENABLED
 
 
+class _FakePopen:
+    """subprocess.Popen の簡易モック（communicate/timeout/returncode/pid）。"""
+
+    def __init__(self, *, returncode=0, stdout="", stderr="", raise_timeout=False):
+        self._returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+        self._raise_timeout = raise_timeout
+        self.pid = 99999  # killpg 対象にはならない（mock で os.killpg を潰す）
+
+    @property
+    def returncode(self):
+        return self._returncode
+
+    def communicate(self, timeout=None):
+        if self._raise_timeout:
+            raise subprocess.TimeoutExpired(cmd="rl-audit", timeout=timeout)
+        return self._stdout, self._stderr
+
+    def wait(self, timeout=None):
+        return self._returncode
+
+
 class TestRunAuditSubprocess:
     """run_audit_subprocess() の正常系 + TIMEOUT + ERROR テスト。"""
 
@@ -233,8 +269,8 @@ class TestRunAuditSubprocess:
         data_dir = tmp_path / "data"
         self._write_growth_state(data_dir, pj, progress=0.65, phase="continuous_growth")
 
-        fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch("subprocess.run", return_value=fake_proc) as m:
+        fake = _FakePopen(returncode=0)
+        with mock.patch("fleet.subprocess.Popen", return_value=fake) as m:
             result = run_audit_subprocess(pj, data_dir=data_dir)
 
         assert result.status == AUDIT_OK
@@ -245,13 +281,19 @@ class TestRunAuditSubprocess:
         # subprocess に CLAUDE_PLUGIN_DATA env が渡されたことを確認
         _, kwargs = m.call_args
         assert kwargs["env"]["CLAUDE_PLUGIN_DATA"] == str(data_dir)
+        assert kwargs.get("start_new_session") is True
+        # argv: flags が `--` 前に来て positional が `--` の後
+        cmd = m.call_args.args[0]
+        assert "--" in cmd
+        assert cmd.index("--") < cmd.index(str(pj))
+        assert cmd.index("--growth") < cmd.index("--")
 
     def test_growth_state_欠損時は_OK_だがスコア_None(self, tmp_path):
         pj = self._make_pj(tmp_path)
         data_dir = tmp_path / "data"
         data_dir.mkdir()  # ディレクトリはあるがファイルなし
-        fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch("subprocess.run", return_value=fake_proc):
+        fake = _FakePopen(returncode=0)
+        with mock.patch("fleet.subprocess.Popen", return_value=fake):
             result = run_audit_subprocess(pj, data_dir=data_dir)
         assert result.status == AUDIT_OK
         assert result.env_score is None
@@ -262,21 +304,23 @@ class TestRunAuditSubprocess:
     def test_TIMEOUT(self, tmp_path):
         pj = self._make_pj(tmp_path)
         data_dir = tmp_path / "data"
-        with mock.patch(
-            "subprocess.run",
-            side_effect=subprocess.TimeoutExpired(cmd="rl-audit", timeout=10),
-        ):
+        fake = _FakePopen(raise_timeout=True)
+        with mock.patch("fleet.subprocess.Popen", return_value=fake), \
+             mock.patch("fleet.os.killpg") as m_killpg:
             result = run_audit_subprocess(pj, timeout=10, data_dir=data_dir)
         assert result.status == AUDIT_TIMEOUT
         assert "timeout" in result.message.lower()
+        # プロセスグループの終了処理が走ったことを確認 (SIGTERM 1 回は呼ばれる)
+        assert m_killpg.called
 
     def test_ERROR_returncode非ゼロ(self, tmp_path):
         pj = self._make_pj(tmp_path)
         data_dir = tmp_path / "data"
-        fake_proc = subprocess.CompletedProcess(
-            args=[], returncode=1, stdout="", stderr="Traceback (most recent call last)\nKeyError: 'foo'"
+        fake = _FakePopen(
+            returncode=1,
+            stderr="Traceback (most recent call last)\nKeyError: 'foo'",
         )
-        with mock.patch("subprocess.run", return_value=fake_proc):
+        with mock.patch("fleet.subprocess.Popen", return_value=fake):
             result = run_audit_subprocess(pj, data_dir=data_dir)
         assert result.status == AUDIT_ERROR
         assert "KeyError" in result.message
@@ -286,8 +330,8 @@ class TestRunAuditSubprocess:
         data_dir = tmp_path / "data"
         data_dir.mkdir()
         (data_dir / f"growth-state-{pj.name}.json").write_text("{ corrupted")
-        fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch("subprocess.run", return_value=fake_proc):
+        fake = _FakePopen(returncode=0)
+        with mock.patch("fleet.subprocess.Popen", return_value=fake):
             result = run_audit_subprocess(pj, data_dir=data_dir)
         assert result.status == AUDIT_ERROR
         assert "state parse" in result.message
@@ -411,9 +455,40 @@ class TestCollectFleetStatus:
             rows = collect_fleet_status(root=tmp_path / "empty")
         assert rows == []
 
+    def test_同名basenameは_AUDIT_ERROR(self, tmp_path):
+        """growth-state cache 衝突を防ぐため同一 basename の PJ は AUDIT_ERROR 扱い。"""
+        root = tmp_path / "repos"
+        pj_a1 = root / "ns_a" / "api"
+        pj_a2 = root / "ns_b" / "api"  # basename "api" が重複
+        (pj_a1 / ".claude").mkdir(parents=True)
+        (pj_a2 / ".claude").mkdir(parents=True)
+
+        # enumerate_projects は直下のみ列挙するので、ns_a / ns_b を直接列挙されるよう
+        # 疑似的に patch する
+        with mock.patch("fleet.enumerate_projects", return_value=[pj_a1, pj_a2]), \
+             mock.patch("fleet.classify_project", return_value=STATUS_ENABLED), \
+             mock.patch("fleet.run_audit_subprocess") as m_audit:
+            rows = collect_fleet_status(root=root)
+
+        assert len(rows) == 2
+        for r in rows:
+            assert r.audit_status == AUDIT_ERROR
+            assert "duplicate basename" in r.message
+        # subprocess を呼ばずに ERROR とマークすることを確認
+        assert m_audit.call_count == 0
+
 
 class TestWriteFleetRun:
     """write_fleet_run() のファイル書き出し検証。"""
+
+    def test_CLAUDE_PLUGIN_DATA_動的解決(self, tmp_path, monkeypatch):
+        """fleet_runs_dir 未指定時は呼び出し時の env を再参照する。"""
+        data_dir = tmp_path / "late_set"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(data_dir))
+        rows = [FleetRow(pj_name="x", status=STATUS_STALE)]
+        path = write_fleet_run(rows, now=datetime(2026, 4, 22, 0, 0, tzinfo=timezone.utc))
+        assert path.parent == data_dir / "fleet-runs"
+        assert path.exists()
 
     def test_命名と内容(self, tmp_path):
         rows = [
@@ -436,23 +511,25 @@ class TestWriteFleetRun:
 class TestMainCLI:
     """main() の CLI 統合。"""
 
-    def test_statusがデフォルトで表を出力しjsonlを書く(self, tmp_path, capsys):
+    def test_statusがデフォルトで表を出力しjsonlを書く(self, tmp_path, capsys, monkeypatch):
         # 空ルートなので rows=[] でヘッダのみ出力される想定
-        fleet_runs = tmp_path / "runs"
-        with mock.patch("fleet._DEFAULT_MATSUKAZE_ROOT", tmp_path / "nope"), \
-             mock.patch("fleet._DEFAULT_FLEET_RUNS_DIR", fleet_runs):
+        data_dir = tmp_path / "data"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(data_dir))
+        with mock.patch("fleet._DEFAULT_MATSUKAZE_ROOT", tmp_path / "nope"):
             rc = main([])
         assert rc == 0
         out = capsys.readouterr().out
         assert "PJ" in out and "STATUS" in out
+        fleet_runs = data_dir / "fleet-runs"
         assert fleet_runs.exists()
         jsonl_files = list(fleet_runs.glob("*.jsonl"))
         assert len(jsonl_files) == 1
 
-    def test_no_writeでjsonlを書かない(self, tmp_path, capsys):
-        fleet_runs = tmp_path / "runs"
-        with mock.patch("fleet._DEFAULT_MATSUKAZE_ROOT", tmp_path / "nope"), \
-             mock.patch("fleet._DEFAULT_FLEET_RUNS_DIR", fleet_runs):
+    def test_no_writeでjsonlを書かない(self, tmp_path, capsys, monkeypatch):
+        data_dir = tmp_path / "data"
+        monkeypatch.setenv("CLAUDE_PLUGIN_DATA", str(data_dir))
+        with mock.patch("fleet._DEFAULT_MATSUKAZE_ROOT", tmp_path / "nope"):
             rc = main(["--no-write"])
         assert rc == 0
+        fleet_runs = data_dir / "fleet-runs"
         assert not fleet_runs.exists()

--- a/scripts/lib/tests/test_fleet.py
+++ b/scripts/lib/tests/test_fleet.py
@@ -10,13 +10,33 @@ Phase 1 で必須の 5 関数をカバー:
 特殊文字を含むパスは Phase 3 で扱う（本テストは扱わない）。
 """
 
+import json
+import os
+import subprocess
 import sys
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 _plugin_root = Path(__file__).resolve().parent.parent.parent.parent
 sys.path.insert(0, str(_plugin_root / "scripts" / "lib"))
 
-from fleet import enumerate_projects, resolve_auto_memory_dir  # noqa: E402
+from fleet import (  # noqa: E402
+    AUDIT_ERROR,
+    AUDIT_OK,
+    AUDIT_TIMEOUT,
+    STATUS_ENABLED,
+    STATUS_NOT_ENABLED,
+    STATUS_STALE,
+    AuditResult,
+    FleetRow,
+    classify_project,
+    enumerate_projects,
+    format_status_table,
+    resolve_auto_memory_dir,
+    run_audit_subprocess,
+)
 
 
 class TestResolveAutoMemoryDir:
@@ -81,3 +101,269 @@ class TestEnumerateProjects:
         (tmp_path / "pj" / "CLAUDE.md").write_text("")
         result = enumerate_projects(tmp_path)
         assert [p.name for p in result] == ["pj"]
+
+
+class TestClassifyProject:
+    """classify_project() の 3 値判定 + settings parse retry テスト。"""
+
+    @staticmethod
+    def _make_pj(tmp_path: Path, name: str) -> Path:
+        pj = tmp_path / "repos" / name
+        (pj / ".claude").mkdir(parents=True)
+        return pj
+
+    @staticmethod
+    def _make_auto_memory(auto_memory_root: Path, pj: Path, age_days: float) -> Path:
+        slug = str(pj.resolve()).replace("/", "-")
+        d = auto_memory_root / slug
+        d.mkdir(parents=True)
+        f = d / "session.jsonl"
+        f.write_text("{}\n")
+        t = time.time() - age_days * 86400
+        os.utime(f, (t, t))
+        return d
+
+    @staticmethod
+    def _write_settings(path: Path, enabled: bool | None) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if enabled is None:
+            data: dict = {"enabledPlugins": {}}
+        else:
+            data = {"enabledPlugins": {"rl-anything@rl-anything": enabled}}
+        path.write_text(json.dumps(data))
+
+    def test_ENABLED_最近の活動あり(self, tmp_path):
+        pj = self._make_pj(tmp_path, "pj1")
+        settings = tmp_path / "settings.json"
+        auto_memory = tmp_path / "projects"
+        self._write_settings(settings, True)
+        self._make_auto_memory(auto_memory, pj, age_days=1)
+        assert classify_project(pj, settings, auto_memory) == STATUS_ENABLED
+
+    def test_STALE_auto_memory_古い(self, tmp_path):
+        pj = self._make_pj(tmp_path, "pj1")
+        settings = tmp_path / "settings.json"
+        auto_memory = tmp_path / "projects"
+        self._write_settings(settings, True)
+        self._make_auto_memory(auto_memory, pj, age_days=40)
+        assert classify_project(pj, settings, auto_memory) == STATUS_STALE
+
+    def test_STALE_auto_memory_欠損(self, tmp_path):
+        pj = self._make_pj(tmp_path, "pj1")
+        settings = tmp_path / "settings.json"
+        auto_memory = tmp_path / "projects"
+        self._write_settings(settings, True)
+        # auto_memory/<slug> を作らない
+        assert classify_project(pj, settings, auto_memory) == STATUS_STALE
+
+    def test_NOT_ENABLED_plugin_disabled(self, tmp_path):
+        pj = self._make_pj(tmp_path, "pj1")
+        settings = tmp_path / "settings.json"
+        auto_memory = tmp_path / "projects"
+        self._write_settings(settings, False)
+        self._make_auto_memory(auto_memory, pj, age_days=1)  # 活動あっても無視
+        assert classify_project(pj, settings, auto_memory) == STATUS_NOT_ENABLED
+
+    def test_NOT_ENABLED_settings_欠損(self, tmp_path):
+        pj = self._make_pj(tmp_path, "pj1")
+        settings = tmp_path / "does_not_exist.json"
+        auto_memory = tmp_path / "projects"
+        assert classify_project(pj, settings, auto_memory) == STATUS_NOT_ENABLED
+
+    def test_settings_parse_失敗_retry_成功(self, tmp_path):
+        pj = self._make_pj(tmp_path, "pj1")
+        settings = tmp_path / "settings.json"
+        auto_memory = tmp_path / "projects"
+        self._make_auto_memory(auto_memory, pj, age_days=1)
+
+        # 1 回目: 破損。2 回目: 正常。
+        settings.write_text("{ broken")
+        call_count = {"n": 0}
+        original_read_text = Path.read_text
+
+        def flaky_read_text(self, *args, **kwargs):
+            if self == settings:
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    return "{ broken"
+                return json.dumps({"enabledPlugins": {"rl-anything@rl-anything": True}})
+            return original_read_text(self, *args, **kwargs)
+
+        with mock.patch.object(Path, "read_text", flaky_read_text):
+            result = classify_project(pj, settings, auto_memory)
+        assert result == STATUS_ENABLED
+        assert call_count["n"] == 2
+
+    def test_settings_parse_失敗_retry_も失敗(self, tmp_path):
+        pj = self._make_pj(tmp_path, "pj1")
+        settings = tmp_path / "settings.json"
+        auto_memory = tmp_path / "projects"
+        self._make_auto_memory(auto_memory, pj, age_days=1)
+        settings.write_text("{ broken")
+        assert classify_project(pj, settings, auto_memory) == STATUS_NOT_ENABLED
+
+
+class TestRunAuditSubprocess:
+    """run_audit_subprocess() の正常系 + TIMEOUT + ERROR テスト。"""
+
+    @staticmethod
+    def _make_pj(tmp_path: Path) -> Path:
+        pj = tmp_path / "pj1"
+        pj.mkdir()
+        return pj
+
+    @staticmethod
+    def _write_growth_state(data_dir: Path, pj: Path, *, progress: float, phase: str) -> Path:
+        data_dir.mkdir(parents=True, exist_ok=True)
+        state_path = data_dir / f"growth-state-{pj.name}.json"
+        state_path.write_text(json.dumps({
+            "progress": progress,
+            "phase": phase,
+            "updated_at": "2026-04-22T00:00:00+00:00",
+            "sessions_count": 10,
+            "crystallizations_count": 0,
+        }))
+        return state_path
+
+    def test_正常系_growth_state_から読み取り(self, tmp_path):
+        pj = self._make_pj(tmp_path)
+        data_dir = tmp_path / "data"
+        self._write_growth_state(data_dir, pj, progress=0.65, phase="continuous_growth")
+
+        fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with mock.patch("subprocess.run", return_value=fake_proc) as m:
+            result = run_audit_subprocess(pj, data_dir=data_dir)
+
+        assert result.status == AUDIT_OK
+        assert result.env_score == 0.65
+        assert result.phase == "continuous_growth"
+        assert result.growth_level == 7  # 0.65 → Lv.7 (LEVEL_THRESHOLDS)
+        assert result.latest_audit == datetime(2026, 4, 22, 0, 0, tzinfo=timezone.utc)
+        # subprocess に CLAUDE_PLUGIN_DATA env が渡されたことを確認
+        _, kwargs = m.call_args
+        assert kwargs["env"]["CLAUDE_PLUGIN_DATA"] == str(data_dir)
+
+    def test_growth_state_欠損時は_OK_だがスコア_None(self, tmp_path):
+        pj = self._make_pj(tmp_path)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()  # ディレクトリはあるがファイルなし
+        fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with mock.patch("subprocess.run", return_value=fake_proc):
+            result = run_audit_subprocess(pj, data_dir=data_dir)
+        assert result.status == AUDIT_OK
+        assert result.env_score is None
+        assert result.phase is None
+        assert result.growth_level is None
+        assert "no growth-state" in result.message
+
+    def test_TIMEOUT(self, tmp_path):
+        pj = self._make_pj(tmp_path)
+        data_dir = tmp_path / "data"
+        with mock.patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="rl-audit", timeout=10),
+        ):
+            result = run_audit_subprocess(pj, timeout=10, data_dir=data_dir)
+        assert result.status == AUDIT_TIMEOUT
+        assert "timeout" in result.message.lower()
+
+    def test_ERROR_returncode非ゼロ(self, tmp_path):
+        pj = self._make_pj(tmp_path)
+        data_dir = tmp_path / "data"
+        fake_proc = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="Traceback (most recent call last)\nKeyError: 'foo'"
+        )
+        with mock.patch("subprocess.run", return_value=fake_proc):
+            result = run_audit_subprocess(pj, data_dir=data_dir)
+        assert result.status == AUDIT_ERROR
+        assert "KeyError" in result.message
+
+    def test_ERROR_growth_state_破損(self, tmp_path):
+        pj = self._make_pj(tmp_path)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / f"growth-state-{pj.name}.json").write_text("{ corrupted")
+        fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with mock.patch("subprocess.run", return_value=fake_proc):
+            result = run_audit_subprocess(pj, data_dir=data_dir)
+        assert result.status == AUDIT_ERROR
+        assert "state parse" in result.message
+
+
+class TestFormatStatusTable:
+    """format_status_table() の表示整形テスト。"""
+
+    def _now(self) -> datetime:
+        return datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc)
+
+    def test_ENABLEDと_STALEと_NOT_ENABLEDが正しく区別される(self):
+        rows = [
+            FleetRow(
+                pj_name="rl-anything",
+                status=STATUS_ENABLED,
+                env_score=0.65,
+                growth_level=7,
+                phase="continuous_growth",
+                latest_audit=datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc),
+                audit_status=AUDIT_OK,
+            ),
+            FleetRow(pj_name="bots", status=STATUS_STALE, audit_status=AUDIT_OK),
+            FleetRow(pj_name="ope-browser", status=STATUS_NOT_ENABLED),
+        ]
+        out = format_status_table(rows, now=self._now())
+        lines = out.strip().split("\n")
+        assert lines[0].startswith("PJ")
+        # ENABLED 行: score/level/phase が表示される
+        assert "0.65" in lines[1]
+        assert "Lv.7" in lines[1]
+        assert "continuous_growth" in lines[1]
+        assert "2h ago" in lines[1]
+        # STALE 行: score=N/A, 他は —
+        assert "N/A" in lines[2]
+        assert "—" in lines[2]
+        # NOT_ENABLED 行: audit も —
+        parts = lines[3].split()
+        assert parts[0] == "ope-browser"
+        assert parts[1] == "NOT_ENABLED"
+
+    def test_TIMEOUT_と_ERROR行(self):
+        rows = [
+            FleetRow(pj_name="a", status=STATUS_ENABLED, audit_status=AUDIT_TIMEOUT),
+            FleetRow(pj_name="b", status=STATUS_ENABLED, audit_status=AUDIT_ERROR, message="boom"),
+        ]
+        out = format_status_table(rows, now=self._now())
+        assert "TIMEOUT" in out
+        assert "ERROR" in out
+
+    def test_列幅は最長セルに揃う(self):
+        rows = [
+            FleetRow(pj_name="short", status=STATUS_STALE),
+            FleetRow(pj_name="very-long-project-name", status=STATUS_STALE),
+        ]
+        out = format_status_table(rows, now=self._now())
+        lines = out.strip().split("\n")
+        # ヘッダ行の "STATUS" と同じ offset に各行の STALE 列が来る
+        status_offset = lines[0].index("STATUS")
+        for data_line in lines[1:]:
+            assert data_line[status_offset:status_offset + len("STALE")] == "STALE"
+
+    def test_相対時刻_分_時間_日(self):
+        now = self._now()
+        rows = [
+            FleetRow(pj_name="min", status=STATUS_ENABLED, env_score=0.5,
+                     latest_audit=now - timedelta(minutes=5), audit_status=AUDIT_OK),
+            FleetRow(pj_name="hour", status=STATUS_ENABLED, env_score=0.5,
+                     latest_audit=now - timedelta(hours=3), audit_status=AUDIT_OK),
+            FleetRow(pj_name="day", status=STATUS_ENABLED, env_score=0.5,
+                     latest_audit=now - timedelta(days=2), audit_status=AUDIT_OK),
+        ]
+        out = format_status_table(rows, now=now)
+        assert "5m ago" in out
+        assert "3h ago" in out
+        assert "2d ago" in out
+
+    def test_空リストでもヘッダだけ出る(self):
+        out = format_status_table([], now=self._now())
+        lines = out.strip().split("\n")
+        assert len(lines) == 1
+        assert "PJ" in lines[0] and "STATUS" in lines[0]

--- a/scripts/lib/tests/test_fleet.py
+++ b/scripts/lib/tests/test_fleet.py
@@ -32,10 +32,13 @@ from fleet import (  # noqa: E402
     AuditResult,
     FleetRow,
     classify_project,
+    collect_fleet_status,
     enumerate_projects,
     format_status_table,
+    main,
     resolve_auto_memory_dir,
     run_audit_subprocess,
+    write_fleet_run,
 )
 
 
@@ -367,3 +370,89 @@ class TestFormatStatusTable:
         lines = out.strip().split("\n")
         assert len(lines) == 1
         assert "PJ" in lines[0] and "STATUS" in lines[0]
+
+
+class TestCollectFleetStatus:
+    """collect_fleet_status() の統合テスト（下位関数は mock）。"""
+
+    def test_ENABLEDとNOT_ENABLEDのPJ混在(self, tmp_path):
+        root = tmp_path / "repos"
+        pj_a = root / "a"
+        pj_b = root / "b"
+        (pj_a / ".claude").mkdir(parents=True)
+        (pj_b / ".claude").mkdir(parents=True)
+
+        def fake_classify(pj, *args, **kwargs):
+            return STATUS_ENABLED if pj.name == "a" else STATUS_NOT_ENABLED
+
+        def fake_audit(pj, *args, **kwargs):
+            return AuditResult(
+                status=AUDIT_OK,
+                env_score=0.70,
+                phase="mature",
+                growth_level=7,
+                latest_audit=datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc),
+            )
+
+        with mock.patch("fleet.classify_project", side_effect=fake_classify), \
+             mock.patch("fleet.run_audit_subprocess", side_effect=fake_audit) as m_audit:
+            rows = collect_fleet_status(root=root)
+
+        assert [r.pj_name for r in rows] == ["a", "b"]
+        assert rows[0].status == STATUS_ENABLED
+        assert rows[0].env_score == 0.70
+        assert rows[1].status == STATUS_NOT_ENABLED
+        assert rows[1].env_score is None
+        # NOT_ENABLED に対しては subprocess を呼ばない
+        assert m_audit.call_count == 1
+
+    def test_rootに候補なしなら空リスト(self, tmp_path):
+        with mock.patch("fleet.classify_project"), mock.patch("fleet.run_audit_subprocess"):
+            rows = collect_fleet_status(root=tmp_path / "empty")
+        assert rows == []
+
+
+class TestWriteFleetRun:
+    """write_fleet_run() のファイル書き出し検証。"""
+
+    def test_命名と内容(self, tmp_path):
+        rows = [
+            FleetRow(pj_name="a", status=STATUS_ENABLED, env_score=0.5,
+                     latest_audit=datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc),
+                     audit_status=AUDIT_OK),
+            FleetRow(pj_name="b", status=STATUS_NOT_ENABLED),
+        ]
+        now = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc)
+        path = write_fleet_run(rows, fleet_runs_dir=tmp_path, now=now)
+        assert path.name == "20260422T120000Z.jsonl"
+        lines = path.read_text().strip().split("\n")
+        assert len(lines) == 2
+        first = json.loads(lines[0])
+        assert first["pj_name"] == "a"
+        assert first["env_score"] == 0.5
+        assert first["latest_audit"] == "2026-04-22T09:00:00+00:00"
+
+
+class TestMainCLI:
+    """main() の CLI 統合。"""
+
+    def test_statusがデフォルトで表を出力しjsonlを書く(self, tmp_path, capsys):
+        # 空ルートなので rows=[] でヘッダのみ出力される想定
+        fleet_runs = tmp_path / "runs"
+        with mock.patch("fleet._DEFAULT_MATSUKAZE_ROOT", tmp_path / "nope"), \
+             mock.patch("fleet._DEFAULT_FLEET_RUNS_DIR", fleet_runs):
+            rc = main([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "PJ" in out and "STATUS" in out
+        assert fleet_runs.exists()
+        jsonl_files = list(fleet_runs.glob("*.jsonl"))
+        assert len(jsonl_files) == 1
+
+    def test_no_writeでjsonlを書かない(self, tmp_path, capsys):
+        fleet_runs = tmp_path / "runs"
+        with mock.patch("fleet._DEFAULT_MATSUKAZE_ROOT", tmp_path / "nope"), \
+             mock.patch("fleet._DEFAULT_FLEET_RUNS_DIR", fleet_runs):
+            rc = main(["--no-write"])
+        assert rc == 0
+        assert not fleet_runs.exists()


### PR DESCRIPTION
## Summary

fleet 構想 (#68) の **Phase 1 MVP** — 全 PJ 横断で rl-anything の健康状態を一覧表示する「4 本目の柱」の基礎実装。

### 新規コード (scripts/lib/fleet.py, 430 行)
5 つのコア関数を TDD で実装:

| 関数 | 役割 |
|------|------|
| `enumerate_projects(root)` | `~/matsukaze-utils/*` を `.claude/` or `CLAUDE.md` で絞り込み、ドット dir 除外 |
| `classify_project(pj)` | ENABLED / STALE / NOT_ENABLED 3 値判定 (settings.enabledPlugins + auto-memory 30 日 mtime) + parse retry |
| `run_audit_subprocess(pj)` | subprocess で `bin/rl-audit --growth --skip-rescore` 実行、growth-state JSON から env_score/phase/level 取得、TIMEOUT/ERROR 区別 |
| `format_status_table(rows)` | 7 列整列 + 相対時刻 (m/h/d ago) + N/A 表示 |
| `resolve_auto_memory_dir(pj)` | Phase 3 snapshot 準備 (auto-memory 命名規則逆引き) |

`collect_fleet_status` は `ThreadPoolExecutor(max_workers=2)` で並列化。STATUS_ENABLED の PJ のみ subprocess audit を呼ぶ最適化 (STALE/NOT_ENABLED は classify のみで高速)。fleet-run 履歴は `<DATA_DIR>/fleet-runs/<ts>.jsonl` に追記。

### エントリポイント
- `bin/rl-fleet` CLI wrapper

## Design doc
`~/.gstack/projects/min-sys-rl-anything/matsukaze-takashi-main-design-20260422-140954.md`

## Test Coverage
- **30 unit tests** (scripts/lib/tests/test_fleet.py)
- カバレッジ対象: 5 コア関数 + 統合 (`collect_fleet_status` / `write_fleet_run` / `main` CLI)
- TIMEOUT / ERROR / settings parse retry を含む異常系テスト

## Perf 実測 (設計要件)
- **目標**: 6 PJ を 3 秒以内
- **実測**: 7 PJ を 1.05s (余裕あり)

## Pre-landing Review
`/review` を事前実行し 2 件 P1 + 3 件 informational を指摘。修正コミット `2c53c90 fix(fleet): address pre-landing review` を追加:
1. `_DEFAULT_DATA_DIR` が `CLAUDE_PLUGIN_DATA` env を無視していた silent data mismatch バグ → `rl_common.DATA_DIR` alias で解決。実測で `CLAUDE_PLUGIN_DATA=/tmp/x rl-fleet status` が正しく別 DATA_DIR に書き込みかつ読み取ることを確認
2. `resolve_auto_memory_dir` が `if __name__ == "__main__"` 後に定義されていた foot-gun → 前に移動
3. unreachable `return None` 削除

## Out of scope
- **既存 audit.py の duckdb バグ**: `CLAUDE_PLUGIN_DATA` 未設定 + 実 usage.jsonl あり環境で `Conversion Error: Malformed JSON` 発生 (main branch でも再現)。fleet は `AUDIT_ERROR` として正しく surface するが、根本修正は別 issue で追跡推奨
- CLAUDE.md の柱 3→4 narrative 更新 (設計で「Phase 1 完了後に実施」と明記されているため、このPR merge 後に別 PR で対応)
- Phase 2 (audit-all --parallel / global rules 整合性チェック) / Phase 3 (介入層 + rollback)

## Test plan
- [x] 30 fleet unit tests pass
- [x] smoke test: `bin/rl-fleet status` が 7 PJ を 1.05s で表示
- [x] `CLAUDE_PLUGIN_DATA` env 尊重 (フルパスの subprocess → growth-state 読み取り経路を dogfood)
- [x] fleet-runs jsonl 書き出し確認
- [x] pre-landing review 全指摘対応済
- [ ] Phase 1 実運用 (merge 後に別 PJ 含む日次 `rl-fleet status` 運用でバリデーション)

🤖 Generated with [Claude Code](https://claude.com/claude-code)