### PR TITLE
chore(release): v1.34.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "rl-anything",
       "source": "./",
       "description": "Automatic skill/rule optimization using direct LLM patches with fitness evaluation and human approval workflow",
-      "version": "1.33.0",
+      "version": "1.34.0",
       "author": {
         "name": "min-sys"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rl-anything",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "スキル/ルールの直接パッチ最適化と自律進化ループ",
   "author": {
     "name": "min-sys"

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ generations/
 .claude/constitutional_cache.json
 .claude/principles.json
 release-notes-review-workspace/
+prompt-optimizer-bench/
 docs/slides/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+- **`skills/release-notes-review/evals/evals.json`** — skill-creator 互換 eval データ（3 ケース）を初 commit。他スキル evals の先例として位置付け。動的生成（`scripts/lib/trigger_eval_generator.py`）とは役割が異なる（手書き回帰テストケース）
+
 ### Fixed
+- **`.gitignore` に `prompt-optimizer-bench/` 追加（暫定）** — 2026-03-07 ADR で min-sys org の独立 repo として作成予定だが未実行のまま rl-anything ワーキング配下に置かれていた。独立 repo 化は tracking issue で別タスク化。暫定的に untracked ノイズを解消
 - **`.gitignore` に scratch ファイル追加** — `.claude/agent-memory/` / `.claude/constitutional_cache.json` / `.claude/principles.json` / `release-notes-review-workspace/` を ignore 対象に追加。`claude plugin tag` の clean working tree チェック通過 + 日常作業での untracked ノイズ削減（release-notes-review v2.1.118 post-merge で検出）
 - **`.claude-plugin/marketplace.json` の version ドリフトを同期** — `plugin.json` (1.33.0) と `marketplace.json` plugins[0].version (0.8.0) が 33 bump 分乖離していた問題を修正。`claude plugin tag` (CC v2.1.118) が両者整合を要求するためリリースフローの前提整備
 - **SPEC.md / CLAUDE.md / spec/api.md の fitness 関数数を 9個 → 8個に統一** — `scripts/rl/fitness/` の実体は 7 ファイル（`coherence` / `telemetry` / `constitutional` / `chaos` / `environment` / `skill_quality` / `plugin`）+ `default`（LLM 汎用評価、専用ファイルなし）= 8個。`config.py` と `principles.py` は supporting モジュール（閾値集約 / 原則抽出）であり fitness ではない。SPEC.md L41 の「9個組み込み」、spec/api.md L33 の「9個: ... `principles`」、CLAUDE.md listing（`plugin` 欠落）を README.md と整合させた（refs #85 Next Actions #4）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,19 @@
 
 ## [Unreleased]
 
-### Added
-- **`skills/release-notes-review/evals/evals.json`** — skill-creator 互換 eval データ（3 ケース）を初 commit。他スキル evals の先例として位置付け。動的生成（`scripts/lib/trigger_eval_generator.py`）とは役割が異なる（手書き回帰テストケース）
-
-### Fixed
-- **`.gitignore` に `prompt-optimizer-bench/` 追加（暫定）** — 2026-03-07 ADR で min-sys org の独立 repo として作成予定だが未実行のまま rl-anything ワーキング配下に置かれていた。独立 repo 化は tracking issue で別タスク化。暫定的に untracked ノイズを解消
-- **`.gitignore` に scratch ファイル追加** — `.claude/agent-memory/` / `.claude/constitutional_cache.json` / `.claude/principles.json` / `release-notes-review-workspace/` を ignore 対象に追加。`claude plugin tag` の clean working tree チェック通過 + 日常作業での untracked ノイズ削減（release-notes-review v2.1.118 post-merge で検出）
-- **`.claude-plugin/marketplace.json` の version ドリフトを同期** — `plugin.json` (1.33.0) と `marketplace.json` plugins[0].version (0.8.0) が 33 bump 分乖離していた問題を修正。`claude plugin tag` (CC v2.1.118) が両者整合を要求するためリリースフローの前提整備
-- **SPEC.md / CLAUDE.md / spec/api.md の fitness 関数数を 9個 → 8個に統一** — `scripts/rl/fitness/` の実体は 7 ファイル（`coherence` / `telemetry` / `constitutional` / `chaos` / `environment` / `skill_quality` / `plugin`）+ `default`（LLM 汎用評価、専用ファイルなし）= 8個。`config.py` と `principles.py` は supporting モジュール（閾値集約 / 原則抽出）であり fitness ではない。SPEC.md L41 の「9個組み込み」、spec/api.md L33 の「9個: ... `principles`」、CLAUDE.md listing（`plugin` 欠落）を README.md と整合させた（refs #85 Next Actions #4）
-- **SPEC.md の hot 86 行 → 79 行に縮小** — L2 caution 閾値（80）超過を解消。Key Design Decisions セクションのカテゴリ別 ADR リスティング（6 行）を `spec/architecture.md#key-design-decisions-カテゴリ別サマリ` へ移動し、SPEC.md は 3 行のポインタに圧縮（refs #85 Next Actions #5）
+## [1.34.0] - 2026-04-24
 
 ### Added
 - **リリースフロー刷新（`claude plugin tag` 導入）** — `.claude/rules/commit-version.md` を更新し、bump 時は plugin.json + marketplace.json + CHANGELOG の三者同期 + main マージ後の `claude plugin tag --push` で `rl-anything--v<version>` タグ作成を明記。過去 chore(release)/feat(vX.Y.Z) コミット 54 件分（v0.4.0〜v1.33.0）の git tag 欠損を historical backfill で復元（release-notes-review v2.1.118 で検出）
 - **fleet スキル Phase 1 — `bin/rl-fleet status` CLI**: 全 PJ 横断で rl-anything の健康状態を一覧表示する「4 本目の柱」の基礎実装（issue #68）。`scripts/lib/fleet.py` に 5 つのコア関数を TDD で実装: `enumerate_projects` (`~/matsukaze-utils/*` を `.claude/` or `CLAUDE.md` で絞り込み、ドットディレクトリ除外) / `classify_project` (settings.json `enabledPlugins` + auto-memory 30 日 mtime ハイブリッド 3 値判定 + parse retry) / `run_audit_subprocess` (subprocess で `bin/rl-audit --growth --skip-rescore` 実行、growth-state JSON から env_score/phase/level を取得、TIMEOUT/ERROR 区別) / `format_status_table` (7 列整列 + 相対時刻フォーマット + N/A 表示) / `resolve_auto_memory_dir` (Phase 3 snapshot 準備)。`collect_fleet_status` は `ThreadPoolExecutor(max_workers=2)` で並列化し、STATUS_ENABLED の PJ のみ subprocess audit を呼ぶ最適化。fleet-run 履歴は `<DATA_DIR>/fleet-runs/<ts>.jsonl` に追記。`_DEFAULT_DATA_DIR` は `rl_common.DATA_DIR` を alias し `CLAUDE_PLUGIN_DATA` env を尊重（pre-landing review で発見した silent data mismatch バグを修正）。perf 実測: 7 PJ / 1.05s（設計目標 3s / 6 PJ を大幅クリア）。30 unit tests（refs #68）
+- **`skills/release-notes-review/evals/evals.json`** — skill-creator 互換 eval データ（3 ケース）を初 commit。他スキル evals の先例として位置付け。動的生成（`scripts/lib/trigger_eval_generator.py`）とは役割が異なる（手書き回帰テストケース）
+
+### Fixed
+- **`.claude-plugin/marketplace.json` の version ドリフトを同期** — `plugin.json` (1.33.0) と `marketplace.json` plugins[0].version (0.8.0) が 33 bump 分乖離していた問題を修正。`claude plugin tag` (CC v2.1.118) が両者整合を要求するためリリースフローの前提整備
+- **SPEC.md / CLAUDE.md / spec/api.md の fitness 関数数を 9個 → 8個に統一** — `scripts/rl/fitness/` の実体は 7 ファイル（`coherence` / `telemetry` / `constitutional` / `chaos` / `environment` / `skill_quality` / `plugin`）+ `default`（LLM 汎用評価、専用ファイルなし）= 8個。`config.py` と `principles.py` は supporting モジュール（閾値集約 / 原則抽出）であり fitness ではない。SPEC.md L41 の「9個組み込み」、spec/api.md L33 の「9個: ... `principles`」、CLAUDE.md listing（`plugin` 欠落）を README.md と整合させた（refs #85 Next Actions #4）
+- **SPEC.md の hot 86 行 → 79 行に縮小** — L2 caution 閾値（80）超過を解消。Key Design Decisions セクションのカテゴリ別 ADR リスティング（6 行）を `spec/architecture.md#key-design-decisions-カテゴリ別サマリ` へ移動し、SPEC.md は 3 行のポインタに圧縮（refs #85 Next Actions #5）
+- **`.gitignore` に scratch ファイル追加** — `.claude/agent-memory/` / `.claude/constitutional_cache.json` / `.claude/principles.json` / `release-notes-review-workspace/` を ignore 対象に追加。`claude plugin tag` の clean working tree チェック通過 + 日常作業での untracked ノイズ削減（release-notes-review v2.1.118 post-merge で検出）
+- **`.gitignore` に `prompt-optimizer-bench/` 追加（暫定）** — 2026-03-07 ADR で min-sys org の独立 repo として作成予定だが未実行のまま rl-anything ワーキング配下に置かれていた。独立 repo 化は tracking issue で別タスク化。暫定的に untracked ノイズを解消
 
 ## [1.33.0] - 2026-04-22
 

--- a/skills/release-notes-review/evals/evals.json
+++ b/skills/release-notes-review/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "release-notes-review",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "CC最近アップデートされたっぽいんだけど、自分の環境に適用できる新機能あるか調べて。rl-anythingプラグインだけじゃなくて、グローバルのrulesとかskillsも見てほしい",
+      "expected_output": "Part 1 (Release Notes) と Part 2 (Global Environment Health) の両方を含む2セクション構成レポート。各項目に適用先（プラグイン/グローバル/両方）が明記されている",
+      "files": []
+    },
+    {
+      "id": 1,
+      "prompt": "/rl-anything:release-notes-review --env-only",
+      "expected_output": "Part 1 (Release Notes) はスキップし、Part 2 (Global Environment Health) のみ出力。Rules/Skills/Agents/Settings Hooks/Memory の各セクションが含まれる",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "グローバルのrulesが増えてきたから、CC新機能で不要になったものがないか確認して。あとskillsも重複してるのあれば教えて",
+      "expected_output": "CC代替候補とCC機能重複の検出に焦点。rules の行数チェック・重複検出も含む。グローバル環境の問題点が具体的に列挙される",
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Minor bump (**v1.33.0 → v1.34.0**)。fleet Phase 1 (#83, refs #68) とリリースフロー刷新 (#87) を中心とした feat 集約 + 複数 fix の通常リリース。handover #85 の Next Actions #4 / #5 のクローズも含む。

## SemVer 判定

| Type | 件数 | 支配 |
|------|------|------|
| feat | 3 件（fleet Phase 1 / release flow 刷新 / evals.json 初投入） | **minor** |
| fix | 5 件（marketplace drift / fitness 整合 / SPEC.md 縮小 / gitignore 系 x2） | patch 相当 |

→ **minor (1.34.0)**

## 主要変更

### Added
- **fleet スキル Phase 1 — `bin/rl-fleet status` CLI** — 全 PJ 横断の健康状態を一覧表示する「4 本目の柱」の基礎実装（[ADR-022](../blob/main/docs/decisions/022-fleet-observation-plus-intervention.md), PR #83, refs #68）
- **リリースフロー刷新（`claude plugin tag` 導入）** — bump 時は plugin.json + marketplace.json + CHANGELOG の三者同期 + `claude plugin tag --push` で tag 作成（PR #87）
- **`skills/release-notes-review/evals/evals.json`** — skill-creator 互換 eval データ（3 ケース）初 commit

### Fixed
- **`.claude-plugin/marketplace.json` version drift 同期** — `plugin.json` (1.33.0) と `marketplace.json` (0.8.0) の 33 bump 分乖離を修正（PR #87）
- **fitness 関数数 9個 → 8個統一** — SPEC.md / CLAUDE.md / spec/api.md を README.md と整合（refs #85 Next Actions #4）
- **SPEC.md hot 86 → 79 行縮小** — L2 caution 閾値（80）超過解消、ADR 一覧は spec/architecture.md へ移動（refs #85 Next Actions #5）
- **`.gitignore` scratch ファイル追加** — `.claude/agent-memory/` 等（PR #89）
- **`.gitignore` prompt-optimizer-bench/ 追加** — 独立 repo 化までの暫定措置（ea0b8b2）

## 変更ファイル

- `.claude-plugin/plugin.json`: `"version": "1.33.0"` → `"1.34.0"`
- `.claude-plugin/marketplace.json` plugins[0].version: `"1.33.0"` → `"1.34.0"`
- `CHANGELOG.md`: `[Unreleased]` を `[1.34.0] - 2026-04-24` に変換、セクション重複を整理、新 `[Unreleased]` を最上位に追加

## Test plan

- [x] `plugin.json` / `marketplace.json` の JSON 妥当性（`python3 -c 'import json; json.load(...)'`）
- [x] CHANGELOG.md の `[Unreleased]` が空で残り、`[1.34.0]` セクションに従来 Unreleased 内容が移っていること
- [x] CHANGELOG.md のセクション重複（`### Added` 2 重）を解消済み
- [x] v1.33.0 以降の main コミット全てが CHANGELOG に対応（#83/#84/#87/#89 + ea0b8b2 + #85 関連）
- [x] `plugin.json` と `marketplace.json` の version が両方 1.34.0 で一致（commit-version rule 準拠）
- [ ] main マージ後に `claude plugin tag --push` で `rl-anything--v1.34.0` タグ作成

## Post-merge action

```bash
claude plugin tag --push  # rl-anything--v1.34.0 を作成
```

refs #68, #85, #87 (merged), #89 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)